### PR TITLE
Overhauled Actionable Notifications page

### DIFF
--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -2,13 +2,13 @@
 title: "Actionable notifications"
 ---
 
-Actionable notifications allow you to attach 1-4 custom buttons to a notification. When one of the actions is selected Home Assistant will be notified which action was chosen. This allows you to build complex automations.
+Actionable notifications allow you to attach up to four buttons underneath an expanded iOS notification. These buttons are associated with automations of your choice, allowing you to perform powerful tasks with literally the press of a button!
 
-Examples of actionable notifications:
+Some useful examples of actionable notifications:
 
-- A notification is sent whenever motion is detected in your home while you are away or asleep. You can add an action to Sound Alarm. When tapped, Home Assistant is notified that the `sound_alarm` action was selected. You can add an automation to sound the burglar alarm whenever this event is seen.
-- Someone rings your front door bell. You can send an action to lock or unlock your front door. When tapped, a notification is sent back to Home Assistant upon which you can build automations.
-- Send a notification whenever your garage door opens with actions to open and close the garage.
+- A notification is sent whenever motion is detected in your home while you're away or asleep. A "Sound Alarm" action button is displayed alongside the notification, that when tapped, will sound your burglar alarm.
+- Someone rings your front doorbell. You receive a notification with a [live camera stream](dynamic-content.md) of the visitor outside along with action buttons to lock or unlock your front door.
+- Receive a notification whenever your garage door opens with action buttons to open or close the garage.
 
 ![Actionable notifications allow the user to send a command back to Home Assistant.](assets/ios/actions.png)
 
@@ -30,25 +30,28 @@ When sending a notification:
 ![How the iOS device and Home Assistant work together to enable actionable notifications.](assets/NotificationActionFlow.png)
 
 ## Definitions
-- Category - A category represents a type of notification that the app might receive. Think of it as a unique group of actions.
-- Actions - An action consists of a button title and the information that iOS needs to notify the app when the action is selected. You create separate action objects for distinct action your app supports.
+- **Category** - A category represents a type of notification that the app might receive. Think of it as a unique group of actions.
+- **Actions** - An action consists of a button title and the information that iOS needs to notify the app when the action is selected. You create separate action objects for distinct action your app supports.
 
 ## Category parameters
-
-- **name** (*Required*): A friendly name for this category.
-- **identifier** (*Required*): A unique identifier for the category. Must be lowercase and have no special characters or spaces.
-- **actions** (*Required*): A list of actions.
+Name | Default | Description
+------------ | ------------- | -------------  
+`name:` | **required** | A friendly name for this category.
+`identifier:` | **required** | A unique identifier for the category. Must be lowercase and have no special characters or spaces.
+`actions:` | **required** | A list of actions. See below.
 
 ## Actions parameters
 
-- **identifier** (*Required*): A unique identifier for this action. Must be uppercase and have no special characters or spaces. Only needs to be unique to the category, not unique globally.
-- **title** (*Required*): The text to display on the button. Keep it short.
-- **activationMode** (*Optional*): The mode in which to run the app when the action is performed. Setting this to `foreground` will make the app open after selecting. Default value is `background`.
-- **authenticationRequired** (*Optional*): If `true`, the user must unlock the device before the action is performed.
-- **destructive** (*Optional*): When the value of this property is a truthy value, the system displays the corresponding button differently to indicate that the action is destructive (text color is red).
-- **behavior** (*Optional*): When `textInput` the system provides a way for the user to enter a text response to be included with the notification. The entered text will be sent back to Home Assistant. Default value is `default`.
-- **textInputButtonTitle** (*Optional*): The button label. *Required* if `behavior` is `textInput`.
-- **textInputPlaceholder** (*Optional*): The placeholder text to show in the text input field. Only used if `behavior` is `textInput` and the device runs iOS 10.
+Name | Default | Description
+------------ | ------------- | -------------  
+`identifier:` | **required** | A unique identifier for this action. Must be uppercase and have no special characters or spaces. Only needs to be unique to the category, not unique globally.
+`title:` | **required** | The text to display on the button. Keep it short.
+`activationMode:` | optional | The mode in which to run the app when the action is performed. Setting this to `foreground` will make the app open after selecting. Default value is `background`.
+`authenticationRequired:` | optional | If `true`, the user must unlock the device before the action is performed.
+`destructive:` | optional | When `true`, the corresponding button is displayed with a red text color to indicate the action is destructive.
+`behavior:` | optional | When `textInput` the system provides a way for the user to enter a text response to be included with the notification. The entered text will be sent back to Home Assistant. Default value is `default`.
+`textInputButtonTitle:` | optional* | The button label. *Required* if `behavior` is `textInput`.
+`textInputPlaceholder:` | optional | The placeholder text to show in the text input field. Only used if `behavior` is `textInput` and the device runs iOS 10.
 
 Here's a fully built example configuration:
 
@@ -80,11 +83,11 @@ Here is an example automation to send a notification with a category in the payl
 
 ```yaml
 automation:
-  - alias: Notify iOS app
+  - alias: Notify Mobile app
     trigger:
       ...
     action:
-      service: notify.ios_robbies_iphone_7_plus
+      service: notify.mobile_app_<your_device_id_here>
       data:
         message: "Something happened at home!"
         data:
@@ -131,6 +134,6 @@ Notes:
 
 ## Compatibility with different devices
 
-* For devices that support "Force Touch" / "3D Touch" - a long press on the notification will cause the actions to appear. Devices such as iPhone 6S, iPhone 6S Plus, iPhone 7, iPhone 7 Plus, iPhone 8, iPhone 8 Plus, iPhone X, iPhone XS, iPhone XS Max as well as some iPad and Apple Watch models.
+* For devices that support "Force Touch" / "3D Touch" (most Apple devices from the last 4-5 years) - a firm press on the notification will expand it, showing the action buttons underneath. Supported devices include the iPhone 6S, iPhone 6S Plus, iPhone 7, iPhone 7 Plus, iPhone 8, iPhone 8 Plus, iPhone X, iPhone XS, iPhone XS Max as well as some iPad and Apple Watch models.
 
-* For device that do not support this feature - a left to right swipe on the notification + tap on 'View' button, will cause the relevant actions to appear. Devices such as iPhone 6 and below, iPhone SE, iPhone XR as some iPad models.
+* For devices that do not support "Force Touch" (such as the iPhone 6 and below, iPhone SE, iPhone XR and some iPad models), you instead perform a left to right swipe on the notification, then tap on the 'View' button. This will expand the notification and show the relevant action buttons underneath. 


### PR DESCRIPTION
* Rewrote intro text
* Simplified and tweaked examples, including cross-linking to dynamic content page (please check to make sure i did that part correctly)
* Added bold/strong markup in Definitions section 
* Converted Category parameters to table
* Converted Actions parameters to table
* Updated notify.ios prefix to notify.mobile_app
* Revamped the 3D Touch instructions to clarify things a little better

In other words, practically the entire page 😛 