### PR TITLE
switch back to ios for events

### DIFF
--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -25,7 +25,7 @@ When sending a notification:
 2. Push notification delivered to device
 3. User opens notification.
 3. Action tapped
-4. Identifier of action sent back to HA as the `actionName` property of the event `mobile_app.notification_action_fired`, along with other metadata such as the device and category name.
+4. Identifier of action sent back to HA as the `actionName` property of the event `ios.notification_action_fired`, along with other metadata such as the device and category name.
 
 ![How the iOS device and Home Assistant work together to enable actionable notifications.](assets/NotificationActionFlow.png)
 
@@ -100,7 +100,7 @@ automation:
             my_custom_data: foo_bar
 ```
 
-When an action is selected an event named `mobile_app.notification_action_fired` will be emitted on the Home Assistant event bus. Below is an example payload.
+When an action is selected an event named `ios.notification_action_fired` will be emitted on the Home Assistant event bus. Below is an example payload.
 
 ```json
 {
@@ -119,7 +119,7 @@ automation:
   - alias: Sound the alarm
     trigger:
       platform: event
-      event_type: mobile_app.notification_action_fired
+      event_type: ios.notification_action_fired
       event_data:
         actionName: SOUND_ALARM
     action:


### PR DESCRIPTION
`mobile_app.notification_action_fired` is 37 characters, above the database limitation of 35. So decision was made to switch back to the `ios` prefix for these events. Docs have been updated to reflect the change.