### PR TITLE
Simplify Notifications

### DIFF
--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -96,8 +96,6 @@ automation:
         message: "Something happened at home!"
         data:
           push:
-            badge: 5
-            sound: <SOUND FILE HERE>
             category: "alarm" # Needs to match the top level identifier you used in the ios configuration
           action_data: # Anything passed in action_data will get echoed back to Home Assistant.
             entity_id: light.test

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -128,7 +128,4 @@ Now, you can send notifications to everyone in the group using:
         service: notify.ALL_DEVICES
         data:
           message: "Something happened at home!"
-          data:
-            push:
-              badge: 5
 ```

--- a/docs/notifications/dynamic-content.md
+++ b/docs/notifications/dynamic-content.md
@@ -62,8 +62,6 @@ data:
     entity_id: camera.living_room_camera
 ```
 
-> Note: This functionality is not available on iOS 10.
-
 You can view an example [here](https://www.youtube.com/watch?v=LmYwpxPKW0g).
 
 <div class='videoWrapper'>

--- a/docs/notifications/dynamic-content.md
+++ b/docs/notifications/dynamic-content.md
@@ -3,7 +3,7 @@ title: "Dynamic content"
 ---
 Dynamic content such as maps and camera streams can be displayed as part of a notification without needing to open an app.
 
-# Map
+## Map
 Will show a centered map with a red pin at the given coordinates.
 
 ```yaml
@@ -18,33 +18,33 @@ data:
       longitude: "-73.968285"
 ```
 
-You may also use a device_tracker for the latitude and longitude coordinates like so: `"{{states.device_tracker.<your_device_id_here>.attributes.latitude}}"` but make sure to use `data_template` in that case. 
+You may also use a device_tracker for the latitude and longitude coordinates like so: `"{{states.device_tracker.<your_device_id_here>.attributes.latitude}}"` but make sure to use `data_template` in that case.
 
-## Showing a second pin
+### Showing a second pin
 
 You can use the following properties under `action_data` to display a second pin. If used, the first pin will be red and the second pin green.
 
-Name | Type | Description
------------- | ------------- | -------------  
-`second_latitude:` | string | The latitude of the second pin.
-`second_longitude:` | string | The longitude of the second pin.
-`shows_line_between_points:` | boolean | Displays a line connecting the first and second pin.
+| Name | Type | Description |
+| ------------ | ------------- | ------------- |  
+| `second_latitude:` | string | The latitude of the second pin. |
+| `second_longitude:` | string | The longitude of the second pin. |
+| `shows_line_between_points:` | boolean | Displays a line connecting the first and second pin. |
 
-## Extra configuration
+### Extra configuration
 
 You can also pass the following option properties under `action_data` to modify the map in various ways. All options listed here accept boolean (`true` / `false`) values.
 
-Name | Type | Description
------------- | ------------- | -------------  
-`shows_compass:` | boolean | Displays a compass control on the map.
-`shows_points_of_interest:` | boolean | Displays point-of-interest (POI) information on the map.
-`shows_scale:` | boolean | Shows scale information on the map.
-`shows_traffic:` | boolean | Displays traffic information on the map.
-`shows_user_location:` | boolean | Attempts to display user's location on the map.
+| Name | Type | Description |
+| ------------ | ------------- | ------------- |
+| `shows_compass:` | boolean | Displays a compass control on the map. |
+| `shows_points_of_interest:` | boolean | Displays point-of-interest (POI) information on the map. |
+| `shows_scale:` | boolean | Shows scale information on the map. |
+| `shows_traffic:` | boolean | Displays traffic information on the map. |
+| `shows_user_location:` | boolean | Attempts to display user's location on the map. |
 
 ![An example of the map dynamic content.](assets/ios/map.png)
 
-# Camera Stream
+## Camera Stream
 
 The preview thumbnail of the notification will display a still image from the camera. When expanded, the notification content displays a real time MJPEG stream if the camera supports it.
 
@@ -70,7 +70,7 @@ You can view an example [here](https://www.youtube.com/watch?v=LmYwpxPKW0g).
 <iframe width="560" height="315" src="https://www.youtube.com/embed/LmYwpxPKW0g" frameborder="0" allowfullscreen></iframe>
 </div>
 
-# Combining with actionable notifications
+## Combining with actionable notifications
 
 As you can see the `category` key is used to tell the device what kind of content extension to use. You can use the same category identifiers in your own custom [actions](actionable.md) to add actions to the content extension.
 
@@ -95,6 +95,6 @@ ios:
             destructive: true
 ```
 
-# Troubleshooting
+## Troubleshooting
 
 If you are having problems with receiving these special notifications, try restarting your phone first. The extensions sometimes fail to register properly until a restart.


### PR DESCRIPTION
Avoid user confusion by simplifying MWEs to avoid using attributes which are not directly relevant to the example.