### PR TITLE
Sidebar should be expanded by default so users can see all docs

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -112,7 +112,7 @@ const siteConfig = {
   translationRecruitingLink: 'https://crwd.in/home-assistant-companion-docs',
   twitter: true,
   twitterUsername: 'home_assistant',
-  docsSideNavCollapsible: true,
+  docsSideNavCollapsible: false,
   algolia: {
     apiKey: '07eb926ba58945e17a895f6ca531e3c2',
     indexName: 'companion-home-assistant',


### PR DESCRIPTION
Sidebar being collapsed by default was hiding a bunch of useful pages. 