### PR TITLE
Remove Wi-Fi from Cellular Technology attribute

### DIFF
--- a/docs/integrations/sensors.md
+++ b/docs/integrations/sensors.md
@@ -56,9 +56,8 @@ The following connection types are known by the companion app:
 *   `Cellular`
 *   `No Connection`
 
-A more specific description of the data connection can be found in the `Cellular Technology` attribute of the sensor. Possible values for this attribute are:
+A more specific description of the data connection can be found in the `Cellular Technology` attribute of the sensor (which only appears when on cellular). Possible values for this attribute are:
 
-*   `Wi-Fi`
 *   `4G`
 *   `3G`
 *   `2G`


### PR DESCRIPTION
This attribute only appears when on cellular now, so it wouldn't ever report a Wi-Fi state. Removing.

I've tested `{{ states.sensor.connection_type.attributes['Cellular Technology'] }}` in template editor when on Wi-Fi and nothing gets returned.

Although I left it for now,  I think `No Connection` could probably be removed too. I can't imagine a scenario where that attribute ever gets displayed, because if the phone had no connection it wouldn't be able to communicate with Home Assistant and update the sensors in the first place, right? I disabled Cellular Data from the iOS control center and manually refreshed while on Wi-Fi, still could not get the above template to display `No Connection`...

@TomBrien  you're much smarter than me, does the above paragraph sound right?