### PR TITLE
fix docUrl in index.js

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -7,10 +7,12 @@
 
 const React = require('react');
 
+const siteConfig = require(process.cwd() + '/siteConfig.js');
+
 class Footer extends React.Component {
   docUrl(doc, language) {
     const baseUrl = this.props.config.baseUrl;
-    return baseUrl + 'docs/' + (language ? language + '/' : '') + doc;
+    return baseUrl + (siteConfig.docUrl ? siteConfig.docUrl + '/' : '' ) + (language ? language + '/' : '') + doc;
   }
 
   pageUrl(doc, language) {

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -12,7 +12,7 @@ const siteConfig = require(process.cwd() + '/siteConfig.js');
 class Footer extends React.Component {
   docUrl(doc, language) {
     const baseUrl = this.props.config.baseUrl;
-    return baseUrl + (siteConfig.docUrl ? siteConfig.docUrl + '/' : '' ) + (language ? language + '/' : '') + doc;
+    return baseUrl + (siteConfig.docsUrl ? siteConfig.docsUrl + '/' : '' ) + (language ? language + '/' : '') + doc;
   }
 
   pageUrl(doc, language) {

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -40,20 +40,28 @@ const PopularTopicsSection = ({ language }) => (
         <div style={{ display: "flex", flexDirection: "column", maxWidth: 420 }}>
           <h2>Documentation Structure</h2>
           <p>
-            <b><a href={docUrl('getting_started', language)}>Getting Started</a>.</b>
+            <b><a href={docUrl('getting_started/index', language)}>Getting Started</a>.</b>
             {' '}Getting to know your new best friend.
           </p>
           <p>
-            <b><a href={docUrl('location', language)}>Location</a>.</b>
-            {' '}How to use your daily movements to improve your automations.
+            <b><a href={docUrl('core/index', language)}>Core Features</a>.</b>
+            {' '}The best bits of the Companion App.
           </p>
           <p>
             <b><a href={docUrl('notifications/basic', language)}>Notifications</a>.</b>
             {' '}Remain constantly informed, even when away from home.
           </p>
           <p>
-            <b><a href={docUrl('integrations', language)}>Integrations</a>.</b>
+            <b><a href={docUrl('integrations/index', language)}>Integrations</a>.</b>
             {' '}All the ways you can integrate Home Assistant into iOS, watchOS and other apps.
+          </p>
+          <p>
+            <b><a href={docUrl('misc/index', language)}>Miscellaneous</a>.</b>
+            {' '}Some of the cool advanced feature of the Companion App.
+          </p>
+          <p>
+            <b><a href={docUrl('troubleshooting/setup', language)}>Troubleshooting</a>.</b>
+            {' '}If you need some help, this is a great place to start.
           </p>
         </div>
 

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -19,7 +19,7 @@ function imgUrl(img) {
 }
 
 function docUrl(doc, language) {
-  return siteConfig.baseUrl + 'docs/' + (language ? language + '/' : '') + doc + ".html";
+  return siteConfig.baseUrl + (siteConfig.docUrl ? siteConfig.docUrl + '/' : '' ) + (language ? language + '/' : '') + doc + ".html";
 }
 
 function pageUrl(page, language) {


### PR DESCRIPTION
docUrl had `docs\` hard coded. Changed to reference the option set in in siteConfig.js. Fixed in index.js but also in footer.js, In case we implement there too.