### PR TITLE
Fix typo in docUrl fix

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -19,7 +19,7 @@ function imgUrl(img) {
 }
 
 function docUrl(doc, language) {
-  return siteConfig.baseUrl + (siteConfig.docUrl ? siteConfig.docUrl + '/' : '' ) + (language ? language + '/' : '') + doc + ".html";
+  return siteConfig.baseUrl + (siteConfig.docsUrl ? siteConfig.docsUrl + '/' : '' ) + (language ? language + '/' : '') + doc + ".html";
 }
 
 function pageUrl(page, language) {


### PR DESCRIPTION
Typo fix in `index.js` accidentally staged wrong file earlier and pushed link updates.