### PR TITLE
Update apple watch link on actions page

### DIFF
--- a/docs/core/actions.md
+++ b/docs/core/actions.md
@@ -2,7 +2,7 @@
 title: "Actions"
 ---
 
-Actions is a generic system that allows you to easily integrate the Home Assistant automations system into multiple areas of iOS and [Apple Watch](integrations/apple-watch.md).
+Actions is a generic system that allows you to easily integrate the Home Assistant automations system into multiple areas of iOS and [Apple Watch](../integrations/watch).
 
 # Creating Actions
 Actions are created from the Actions section of the App Configuration page within the companion App. Each action has six required fields:


### PR DESCRIPTION
Update the link on the actions page to apple watch to reflect the new docs structure.