### PR TITLE
Typo fix in notification introduction

### DIFF
--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -33,7 +33,7 @@ automation:
         message: "Ding-dong"
         data:
           push:
-            sounds: default
+            sound: default
 ```
 
 ### Badge


### PR DESCRIPTION
Correct `sounds` to `sound` in example of using sound. Addressing #77 