### PR TITLE
Fix typo in replacing notifications docs

### DIFF
--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -54,7 +54,7 @@ automation:
             badge: 5
 ```
 
-By setting the message to `delete_alert` you can silently update the app badge icon in the background without sending a notification to your phone. 
+By setting the message to `delete_alert` you can silently update the app badge icon in the background without sending a notification to your phone.
 
 ### Subtitle
 A subtitle is supported in addition to the title:
@@ -104,8 +104,9 @@ automation:
       data:
         title: "Motion Detected in Backyard"
         message: "Someone might be in the backyard."
-        apns_headers:
-          apns-collapse-id: "backyard-motion-detected"
+        data:
+          apns_headers:
+            'apns-collapse-id': 'backyard-motion-detected'
 ```
 
 ### Sending notifications to multiple devices

--- a/website/versioned_docs/version-2.0.0/notifications/basic.md
+++ b/website/versioned_docs/version-2.0.0/notifications/basic.md
@@ -104,9 +104,9 @@ automation:
       data:
         title: "Motion Detected in Backyard"
         message: "Someone might be in the backyard."
-          data:
-            apns_headers:
-              'apns-collapse-id': 'backyard-motion-detected'
+        data:
+          apns_headers:
+            'apns-collapse-id': 'backyard-motion-detected'
 ```
 
 ### Sending notifications to multiple devices


### PR DESCRIPTION
Fix typo (indentation) in docs for replacing notifications. Fix for #119