### PR TITLE
Fix typo

### DIFF
--- a/docs/notifications/location.md
+++ b/docs/notifications/location.md
@@ -9,7 +9,7 @@ title: "Requesting location updates"
 You can force a device to attempt to report its location by sending a special notification. The notification is not visible to the device owner and only works when the app is running or in the background. On success the sensor.last_update_trigger will change to "Push Notification".
 
 ```yaml
-automation
+automation:
   - alias: Notify Mobile app
     trigger:
       ...

--- a/website/versioned_docs/version-1.0.0/notifications/location.md
+++ b/website/versioned_docs/version-1.0.0/notifications/location.md
@@ -11,7 +11,7 @@ original_id: location
 You can force a device to attempt to report its location by sending a special notification.
 
 ```yaml
-automation
+automation:
   - alias: Notify iOS app
     trigger:
       ...

--- a/website/versioned_docs/version-2.0.0/notifications/location.md
+++ b/website/versioned_docs/version-2.0.0/notifications/location.md
@@ -8,10 +8,10 @@ original_id: location
 **Do not rely on this functionality due to the time limits mentioned below.**
 </p>
 
-You can force a device to attempt to report its location by sending a special notification. 
+You can force a device to attempt to report its location by sending a special notification.
 
 ```yaml
-automation
+automation:
   - alias: Notify Mobile app
     trigger:
       ...


### PR DESCRIPTION
Add missing `:` in automation example
