### PR TITLE
Add breaking change

### DIFF
--- a/docs/getting_started/migration.md
+++ b/docs/getting_started/migration.md
@@ -12,6 +12,7 @@ The steps below should guide you through the process of migrating from the previ
 -   The new device tracker no longer supports the `device_tracker.see` service.
 -   The battery level and state sensors will be change from `sensor.<device_id>_battery_level` and `sensor.<device_id>_battery_state` to `sensor.battery_level` and `sensor.battery_state`. When you set up additional devices, the new sensors for those device will be distinguished with an identifier on the end (i.e. `sensor.battery_level_2`).
 -   The send manual location update button has been removed along with the footer bar. You can now send an update manually be pulling/swiping down within the app. This will refresh the page and also send a location update. You can also send a location update by tap-and-holding the app icon.
+-   The `group.all_devices` group was maintained by the now legacy `device_tracker` service based on `known_devices.yaml` used by the `ios` integration. Since this is no longer used, device running 2019.1 will not be added to the `group.all_devices`. The new `device_tracker` entities can be associated with `person` entities however which can be grouped in a similar way.
 
 # Requirements
 You need to be running Home Assistant 0.95.0 or newer. The new updated iOS app requires the following integrations to be enabled in your Home Assistant instance:

--- a/website/versioned_docs/version-2.0.0/getting_started/migration.md
+++ b/website/versioned_docs/version-2.0.0/getting_started/migration.md
@@ -10,9 +10,10 @@ The steps below should guide you through the process of migrating from the previ
 -   All notifications need to be updated as the notify service is moving from `notify.ios_<device_id>` to `notify.mobile_app_<device_name>`. In the old version the `device_id` was set in the iOS app settings, after the update the `device_name` is taken from iOS settings (see iOS Settings App>General>About).
 -   Your existing device tracker entity will be obsolete. The old app used `known_devices.yaml` whereas the updated app uses the `mobile_app` integration and entity storage. Your old tracker `device_tracker.device_id` will no longer update, the new tracker will be called `device_tracker.device_name`.
 -   The new device tracker no longer contains attributes such as "trigger: Geographic Region entered". These have all moved to sensors that will be created via the `mobile_app` integration.
--   The new device tracker no longer supports the `device_tracker.see` service. 
+-   The new device tracker no longer supports the `device_tracker.see` service.
 -   The battery level and state sensors will be change from `sensor.<device_id>_battery_level` and `sensor.<device_id>_battery_state` to `sensor.battery_level` and `sensor.battery_state`. When you set up additional devices, the new sensors for those device will be distinguished with an identifier on the end (i.e. `sensor.battery_level_2`).
 -   The send manual location update button has been removed along with the footer bar. You can now send an update manually be pulling/swiping down within the app. This will refresh the page and also send a location update. You can also send a location update by tap-and-holding the app icon.
+-   The `group.all_devices` group was maintained by the now legacy `device_tracker` service based on `known_devices.yaml` used by the `ios` integration. Since this is no longer used, device running 2019.1 will not be added to the `group.all_devices`. The new `device_tracker` entities can be associated with `person` entities however which can be grouped in a similar way.
 
 # Requirements
 You need to be running Home Assistant 0.95.0 or newer. The new updated iOS app requires the following integrations to be enabled in your Home Assistant instance:


### PR DESCRIPTION
Add breaking change that we no longer add to `group.all_devices` as that was legacy `device_tracker`
