### PR TITLE
Add info about CarPlay critical notifications showing on car's built-in screen

### DIFF
--- a/docs/notifications/critical.md
+++ b/docs/notifications/critical.md
@@ -30,3 +30,5 @@ automations:
 ```
 
 If you have previously read the [sounds documentation](sounds.md) this syntax should be mostly familiar. Note the example expands the `sound` attribute to include the `critical: 1` flag, and `volume: 1.0` to set the volume to 100 %.
+
+For **CarPlay** users, it's also worth mentioning that critical notifications are the only ones that can appear on the car's built-in display, making them very useful if you want to know when something critical happens while you're driving.


### PR DESCRIPTION
Add some info about CarPlay critical notifications showing on screen. I have not seen anything online about this, so I tested it : standard HA notifications aren't shown, while critical notifications played a sound and displayed informations on my car's built-in screen.