### PR TITLE
Change navbar title

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ module.exports = {
   projectName: 'companion.home-assistant', // Usually your repo name.
   themeConfig: {
     navbar: {
-      title: 'Home Assistant Apps',
+      title: 'Companion Apps',
       logo: {
         alt: 'Home Assistant',
         src: 'img/logo-pretty.svg',


### PR DESCRIPTION
Previous title was too long and looked bad on mobile browsers. Kept to two words to ensure it isn't clipping on top/bottom edges of the navbar
