### PR TITLE
Convert feature comparison table to html

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -7,63 +7,278 @@ The Home Assistant Companion App provides a convenient way to view and control y
 
 Not all features are supported by Android at the moment but eventually most features will be supported.  Look for the ![android](/assets/android.svg) Android logo to see what is currently supported.
 
-![iOS](/assets/apple.svg) iOS and ![android](/assets/android.svg) Android Feature Comparison:
+## ![iOS](/assets/apple.svg) iOS and ![android](/assets/android.svg) Android Feature Comparison:
 
-| Integrations | ![android](/assets/android.svg) | ![iOS](/assets/apple.svg) |
-| ------ | ------ | ------ |
-| [App Events](../integrations/app-events.md) |  | :white_check_mark: |
-| [Haptic Feedback](../integrations/haptics.md) |  | :white_check_mark: |
-| [Theming](../integrations/theming.md) | :white_check_mark: | :white_check_mark: |
-| [URL Handler](../integrations/url-handler.md) |  | :white_check_mark: |
-| [Universal Links](../integrations/universal-links.md) |  | :white_check_mark: |
-| [X-Callback-URL](../integrations/x-callback-url.md) |  | :white_check_mark: |
-
-| Location Updates | ![android](/assets/android.svg) | ![iOS](/assets/apple.svg) |
-| ------ | ------ | ------ |
-| [App Opened](location.md#overview) | :white_check_mark: | :white_check_mark: |
-| [App Refreshed](location.md#overview) |  | :white_check_mark: |
-| [Background](location.md#overview) | :white_check_mark: | :white_check_mark: |
-| [Enter/Exit Zone](location.md#location-tracking-in-home-assistant-zones) | :white_check_mark: | :white_check_mark: |
-| [iBeacon](location.md#ibeacons) |  | :white_check_mark: |
-| [Request Location Updates](../notifications/location.md) | :white_check_mark: | :white_check_mark: |
-| [Significant Location Change](location.md#location-tracking-when-outside-a-home-assistant-zone) | :white_check_mark: | :white_check_mark: |
-| [URL Handler](location.md#overview) |  | :white_check_mark: |
-| [X-Callback-URL](location.md#overview) |  | :white_check_mark: |
-
-| Notifications | ![android](/assets/android.svg) | ![iOS](/assets/apple.svg) |
-| ------ | ------ | ------ |
-| [Actionable](../notifications/actionable.md) | :white_check_mark: | :white_check_mark: |
-| [Badge](../notifications/basic.md#badge) |  | :white_check_mark: |
-| [Click Action](../notifications/basic.md#notification-click-action) | :white_check_mark: |  |
-| [Color](../notifications/basic.md#notification-color) | :white_check_mark: |  |
-| [Critical Alerts](../notifications/critical.md) | :white_check_mark: | :white_check_mark: |
-| [Dynamic Attachments](../notifications/dynamic-content.md) |  | :white_check_mark: |
-| [Image](../notifications/attachments.md) | :white_check_mark: | :white_check_mark: |
-| [Message](../notifications/basic.md) | :white_check_mark: | :white_check_mark: |
-| [Presentation](../notifications/basic.md#controlling-how-a-notification-is-displayed-when-in-the-foreground) |  | :white_check_mark: |
-| [Replaceable Notifications](../notifications/basic.md#replacing-notifications) | :white_check_mark: | :white_check_mark: |
-| [Request Location Updates](../notifications/location.md) | :white_check_mark: | :white_check_mark: |
-| [Sound](../notifications/sounds.md) |  | :white_check_mark: |
-| [Sticky](../notifications/basic.md#sticky-notification) | :white_check_mark: |  |
-| [Subtitle](../notifications/basic.md#subtitle) |  | :white_check_mark: |
-| [Threads](../notifications/basic.md#thread-id-grouping-notifications) |  | :white_check_mark: |
-| [Title](../notifications/basic.md) | :white_check_mark: | :white_check_mark: |
-| [Video](../notifications/attachments.md) |  | :white_check_mark: |
-
-| Sensors | ![android](/assets/android.svg) | ![iOS](/assets/apple.svg) |
-| ------ | ------ | ------ |
-| [Activity Sensor](sensors.md#activity-sensor) |  | :white_check_mark: |
-| [Average Active Pace](sensors.md#pedometer-sensors) |  | :white_check_mark: |
-| [Battery Level](sensors.md#battery-sensors) | :white_check_mark: | :white_check_mark: |
-| [Battery State](sensors.md#battery-sensors) | :white_check_mark: | :white_check_mark: |
-| [BSSID](sensors.md#connection-type-sensor) | :white_check_mark: | :white_check_mark: |
-| [Connection Type](sensors.md#connection-type-sensor) | :white_check_mark: | :white_check_mark: |
-| [Distance](sensors.md#pedometer-sensors) |  | :white_check_mark: |
-| [Floors Ascended](sensors.md#pedometer-sensors) |  | :white_check_mark: |
-| [Floors Descended](sensors.md#pedometer-sensors) |  | :white_check_mark: |
-| [Geocoded Location](sensors.md#geocoded-location-sensor) |  | :white_check_mark: |
-| [Last Update Trigger](sensors.md#last-update-trigger-sensor) |  | :white_check_mark: |
-| [Sim 1](sensors.md#cellular-provider-sensor) |  | :white_check_mark: |
-| [Sim 2](sensors.md#cellular-provider-sensor) |  | :white_check_mark: |
-| [SSID](sensors.md) |  | :white_check_mark: |
-| [Steps](sensors.md#pedometer-sensors) |  | :white_check_mark: |
+<table>
+  <thead>
+    <tr>
+      <th><strong>Integrations</strong></th>
+      <th><img alt="android" src="/assets/android.svg" /></th>
+      <th><img alt="iOS" src="/assets/apple.svg" /></th>
+      </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="../integrations/app-events.md">App Events</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../integrations/haptics.md">Haptic Feedback</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../integrations/theming.md">Theming</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../integrations/url-handler.md">URL Handler</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../integrations/universal-links.md">Universal Links</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../integrations/x-callback-url.md">X-Callback-URL</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+  </tbody>
+  <thead>
+    <tr>
+      <th><strong>Location Updates</strong></th>
+      <th><img alt="android" src="/assets/android.svg" /></th>
+      <th><img alt="iOS" src="/assets/apple.svg" /></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="location.md#overview">App Opened</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="location.md#overview">App Refreshed</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="location.md#overview">Background</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="location.md#location-tracking-in-home-assistant-zones">Enter/Exit Zone</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="location.md#ibeacons">iBeacon</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/location.md">Request Location Updates</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="location.md#location-tracking-when-outside-a-home-assistant-zone">Significant Location Change</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="location.md#overview">URL Handler</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="location.md#overview">X-Callback-URL</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+  </tbody>
+  <thead>
+    <tr>
+      <th><strong>Notifications</strong></th>
+      <th><img alt="android" src="/assets/android.svg" /></th>
+      <th><img alt="iOS" src="/assets/apple.svg" /></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="../notifications/actionable.md">Actionable</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/basic.md#badge">Badge</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/basic.md#notification-click-action">Click Action</a></td>
+      <td>✅</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/basic.md#notification-color">Color</a></td>
+      <td>✅</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/critical.md">Critical Alerts</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/dynamic-content.md">Dynamic Attachments</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/attachments.md">Image</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/basic.md">Message</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/basic.md#controlling-how-a-notification-is-displayed-when-in-the-foreground">Presentation</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/basic.md#replacing-notifications">Replaceable Notifications</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/location.md">Request Location Updates</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/sounds.md">Sound</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/basic.md#sticky-notification">Sticky</a></td>
+      <td>✅</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/basic.md#subtitle">Subtitle</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/basic.md#thread-id-grouping-notifications">Threads</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/basic.md">Title</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="../notifications/attachments.md">Video</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+  </tbody>
+  <thead>
+    <tr>
+      <th><strong>Sensors</strong></th>
+      <th><img alt="android" src="/assets/android.svg" /></th>
+      <th><img alt="iOS" src="/assets/apple.svg" /></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><a href="sensors.md#activity-sensor">Activity Sensor</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="sensors.md#pedometer-sensors">Average Active Pace</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="sensors.md#battery-sensors">Battery Level</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="sensors.md#battery-sensors">Battery State</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="sensors.md#connection-type-sensor">BSSID</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="sensors.md#connection-type-sensor">Connection Type</a></td>
+      <td>✅</td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="sensors.md#pedometer-sensors">Distance</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="sensors.md#pedometer-sensors">Floors Ascended</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="sensors.md#pedometer-sensors">Floors Descended</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="sensors.md#geocoded-location-sensor">Geocoded Location</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="sensors.md#last-update-trigger-sensor">Last Update Trigger</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="sensors.md#cellular-provider-sensor">Sim 1</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="sensors.md#cellular-provider-sensor">Sim 2</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="sensors.md">SSID</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="sensors.md#pedometer-sensors">Steps</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -7,7 +7,7 @@ The Home Assistant Companion App provides a convenient way to view and control y
 
 Not all features are supported by Android at the moment but eventually most features will be supported.  Look for the ![android](/assets/android.svg) Android logo to see what is currently supported.
 
-## ![iOS](/assets/apple.svg) iOS and ![android](/assets/android.svg) Android Feature Comparison:
+## ![](/assets/apple.svg) iOS and ![](/assets/android.svg) Android Feature Comparison:
 
 <table>
   <thead>


### PR DESCRIPTION
Convert feature comparison  table to html to allow column alignment while keeping the section headers and row shading (mid table headers not supported by markdown)
