### PR TITLE
Add info about self-signed certs for android

### DIFF
--- a/docs/troubleshooting/setup.md
+++ b/docs/troubleshooting/setup.md
@@ -72,3 +72,6 @@ If you find that location updates are not coming in here are a few things to che
 2.  Turn off battery optimizations for the app
 3.  Ensure that the location toggles are enabled in App Configuration in the Android app
 4.  Turn on unrestricted data for the Android app
+
+#### Using a self-signed certificate leads to a blank page in Android
+If you are using a self-signed certificate on Android then you may get stuck at a blank screen after entering and/or selecting your Home Assistant instance. In order to correct this issue you will need to make sure the URL is valid and that you import the certificate into Androids Trusted Certificates. Steps to perform this can be found [here](https://support.google.com/nexus/answer/2844832?hl=en). These steps were written for devices on Android 9+ but are very close for older supported devices.


### PR DESCRIPTION
We have been seeing reports of users getting stuck during onboarding and in most of these cases the user is using a self-signed certificate.  These steps should hopefully help users bypass the issue and use the app.

https://community.home-assistant.io/t/error-when-opening-the-app-from-local-network/171521

https://discordapp.com/channels/330944238910963714/562408603345092636/677569130949509141

https://github.com/home-assistant/home-assistant-android/issues/171

https://github.com/home-assistant/home-assistant-android/pull/194

@jbassett can you check this to make sure I have the correct info?