### PR TITLE
Align download links

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -16,6 +16,10 @@
   --ifm-code-font-size: 95%;
 }
 
+.download-badges {
+  line-height: 0px;
+}
+
 .docusaurus-highlight-code-line {
   background-color: rgb(72, 77, 91);
   display: block;

--- a/src/pages/download.js
+++ b/src/pages/download.js
@@ -16,7 +16,7 @@ function Hello() {
         <div className="container">
           <h1 className="hero__title">Download the Home Assistant Apps</h1>
           <p className="hero__subtitle">Get the apps now!</p>
-          <div className={styles.buttons}>
+          <div className={classnames(styles.buttons, 'download-badges')} >
           <a href="https://apps.apple.com/us/app/home-assistant/id1099568401?mt=8" style={{display:'inline-block', overflow: 'hidden', background: 'url(https://linkmaker.itunes.apple.com/en-us/badge-lrg.svg?releaseDate=2017-04-15&kind=iossoftware&bubble=apple_music) no-repeat center', width: '155px', height: '40px'}}></a>
           <a href='https://play.google.com/store/apps/details?id=io.homeassistant.companion.android&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'>
             <img alt='Get it on Google Play' width="155" src='https://play.google.com/intl/en_gb/badges/static/images/badges/en_badge_web_generic.png'/>


### PR DESCRIPTION
The Google Play and App Store icons don't sit nicely next to each other out of the box so minor CSS tweak to force them to play nice
