### PR TITLE
Enable search

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,6 +66,11 @@ module.exports = {
       copyright: `Copyright © ${new Date().getFullYear()} Home Assistant. Built with Docusaurus.`,
     },
     image: 'img/default-social.png',
+    algolia: {
+      apiKey: '07eb926ba58945e17a895f6ca531e3c2',
+      indexName: 'companion-home-assistant',
+      algoliaOptions: {} // Optional, if provided by Algolia
+    },
   },
   presets: [
     [


### PR DESCRIPTION
Enable the Algolia search component. Will require a clear of Algolia cache before merging. @robbiet480 can you either add me to the team (if such a thing exists on Algolia) or clear the cache. The results are still pulling from the old version. We can remove the do not merge label when that is sorted. I just don't want the search chucking out dead links