### PR TITLE
Edit readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Documentation is build using [Docusaurus V2](https://v2.docusaurus.io/docs/intro
 
 ### Preparing environment
 
-Running the documentation locally requires [NodeJS](https://nodejs.org/en/) and [Yarn](https://yarnpkg.com/) to be installed. Inside a cloned fork of this repository, run:
+Running the documentation locally requires [NodeJS](https://nodejs.org/) and [Yarn](https://classic.yarnpkg.com/docs/install) to be installed. Inside a cloned fork of this repository, run:
 
 ```bash
 $ yarn


### PR DESCRIPTION
Change the Yarn download link to go to stable release of classic. The landing page of yarnpkg.com now goes to instructions for Yarn 2 which are not particularly clear. Also change Node.js link to be language independent 
