### PR TITLE
Add note about data saver for widget

### DIFF
--- a/docs/core/actions.md
+++ b/docs/core/actions.md
@@ -102,12 +102,12 @@ The [Today View Widget](https://support.apple.com/en-gb/HT207122) is another rou
 4.  Rearrange as you'd like and then tap Done.
 
 ## ![android](/assets/android.svg) Android Widget
-The Android app allows the user to create widgets on the home screen so the user can call any Home Assistant service call.  You can add the widget like you normally would for any app depending on your devices launcher.
+The Android app allows the user to create widgets on the home screen so the user can call any Home Assistant service call. You can add the widget like you normally would for any app depending on your devices launcher. The widget will not work when Data Saver is enabled, you will also need to ensure that background data for the app is enabled.
 
 1.  Long press on any open space in the home screen
 2.  Scroll down to Home Assistant in the widget list
 3.  Drag the widget to an open space on the home screen
 4.  Select the service call you wish to perform
 5.  Fill in the required service data for the selected service call
-6.  Supply a name and icon the widget
+6.  Supply a name and icon for the widget
 7.  Save the widget

--- a/docs/troubleshooting/setup.md
+++ b/docs/troubleshooting/setup.md
@@ -80,3 +80,10 @@ If you find that location updates are not coming in here are a few things to che
 
 #### Using a self-signed certificate leads to a blank page in Android
 If you are using a self-signed certificate on Android then you may get stuck at a blank screen after entering and/or selecting your Home Assistant instance. In order to correct this issue you will need to make sure the URL is valid and that you import the certificate into Androids Trusted Certificates. Steps to perform this can be found [here](https://support.google.com/nexus/answer/2844832?hl=en). These steps were written for devices on Android 9+ but are very close for older supported devices.
+
+#### Android widget is not working
+If you find that a widget is no longer working then these steps may help you resolve the issue.
+
+1.  Check that data saver is disabled on the device, the widget will not work when it is enabled.
+2.  Check that background data for the Home Assistant app is enabled.
+3.  Remove and recreate the widget.


### PR DESCRIPTION
We had a user encounter a widget issue when data saver is enabled, in order for the widget to work users will need to make sure data saver is off.

Also good time to add a troubleshooting step as well :)

https://github.com/home-assistant/home-assistant-android/issues/434