### PR TITLE
Move android widgets to its own section

### DIFF
--- a/docs/core/actions.md
+++ b/docs/core/actions.md
@@ -3,27 +3,29 @@ title: "Actions"
 id: 'actions'
 ---
 
-Actions is a generic system that allows you to easily integrate the Home Assistant automations system into multiple areas of iOS/Android and [Apple Watch](../integrations/watch/index.md).
+![iOS](/assets/apple.svg) iOS Specific
+
+Actions is a generic system that allows you to easily integrate the Home Assistant automations system into multiple areas of iOS and [Apple Watch](../integrations/watch/index.md).
 
 # Creating Actions
-Actions are created from the Actions section of the App Configuration page within the companion App for iOS.  For Android the actions are created in the notification service call. Each action has required fields depending on your device:
-*   `Name`: the name of the action, this will be returned in the [Home Assistant event](https://www.home-assistant.io/docs/configuration/events/) fired by the app. ![iOS](/assets/apple.svg) ![android](/assets/android.svg)
-*   `Text`: the descriptive text shown on the phone and watch. It is best to keep this relatively short as there is limited space on each action's button. ![iOS](/assets/apple.svg) ![android](/assets/android.svg)
-*   `Text Color`: the color of the text defined above ![iOS](/assets/apple.svg)
-*   `Background Color`: the color of the button created for the action. ![iOS](/assets/apple.svg)
-*   `Icon`: an icon to display to the left of the text on the action's button  ![iOS](/assets/apple.svg)
-*   `Icon Color`: the color of the icon on the action's button. ![iOS](/assets/apple.svg)
+Actions are created from the Actions section of the App Configuration page within the companion App for iOS. Each action has required fields depending on your device:
+*   `Name`: the name of the action, this will be returned in the [Home Assistant event](https://www.home-assistant.io/docs/configuration/events/) fired by the app.
+*   `Text`: the descriptive text shown on the phone and watch. It is best to keep this relatively short as there is limited space on each action's button.
+*   `Text Color`: the color of the text defined above.
+*   `Background Color`: the color of the button created for the action.
+*   `Icon`: an icon to display to the left of the text on the action's button.
+*   `Icon Color`: the color of the icon on the action's button.
 
 For the three color fields, the color is selected by tapping the color-picker circle in each field.
 
 # Using Actions
-When an action button is pressed a `ios.action_fired` or `mobile_app_notification_action` event is fired on Home Assistant's event bus. The event data consists of a JSON-formatted dictionary of attributes relating to the action.
+When an action button is pressed a `ios.action_fired` event is fired on Home Assistant's event bus. The event data consists of a JSON-formatted dictionary of attributes relating to the action.
 
 | Attribute | Value |
 | ------ | ------ |
 | `context` | Child dictionary relating the user that triggered the event and the ID of the event |
 | `data` | Child dictionary containing key information about the action and its origin |
-| `event_type` | Always `ios.action_fired` or `mobile_app_notification_action` |
+| `event_type` | Always `ios.action_fired` |
 | `origin` | Always `REMOTE` |
 | `time_fired` | Data and time the action was fired, formatted as an [ISO timestamp](https://en.wikipedia.org/wiki/ISO_8601) , e.g. midnight on Christmas day in Lapland (Eastern European Time, UTC+2), would be `2019-12-25T00:00.000000+02:00`. |
 
@@ -48,7 +50,7 @@ The attributes contained within `context` are:
 
 Actions can be used to trigger automations within Home Assistant. An example `configuration.yaml` entry might be:
 
-![iOS](/assets/apple.svg) iOS Example
+Example
 
 ```yaml
 automation:
@@ -63,51 +65,21 @@ automation:
       service: light.turn_off
       entity_id: group.all_lights
 ```
-
-![android](/assets/android.svg) Android Example
-
-```yaml
-automation:
-  - alias: "Action Turn Lights Off"
-    initial_state: true
-    trigger:
-      - platform: event
-        event_type: mobile_app_notification_action
-        event_data:
-          action: 'Bed Time'
-    action:
-      service: light.turn_off
-      entity_id: group.all_lights
-```
-
 Note that attributes located in the `data` and `context` are accessed through `event_data` and `event_context` respectively within the automation.
 
-You can use the Events page within Home Assistant's developer tools to show all information contained with the event for a particular event by subscribing to `ios.action_fired` or `mobile_app_notification_action` and triggering the action from you device.
+You can use the Events page within Home Assistant's developer tools to show all information contained with the event for a particular event by subscribing to `ios.action_fired` and triggering the action from you device.
 
-# ![iOS](/assets/apple.svg) Apple Watch
+# Apple Watch
 The [Apple Watch App](integrations/watch/index.md) provides access to actions you have created. Once you have created an action within the Actions page, open the Home Assistant watch and the action list should sync.
 
 
-# ![iOS](/assets/apple.svg) Home Screen Quick Actions
+# Home Screen Quick Actions
 [Home Screen Quick Actions](https://support.apple.com/guide/iphone/keep-apps-handy-iph414564dba/ios#iph1ffcbd691) provides a convenient shortcut to your actions and is accessed by 3D Touching the Home Assistant companion app icon on your home screen.
 
-# Widgets
-
-## ![iOS](/assets/apple.svg) Today View Widget
+# Today View Widget
 The [Today View Widget](https://support.apple.com/en-gb/HT207122) is another route through which actions can be fired. To add the Home Assistant widget to your Today View:
 
 1.  Swipe right while on the Home screen or Lock screen.
 2.  Scroll to the very bottom and tap the Edit button.
 3.  Find the "Home Assistant - Actions" widget in the "More Widgets" list and then tap the green + button to add it.
 4.  Rearrange as you'd like and then tap Done.
-
-## ![android](/assets/android.svg) Android Widget
-The Android app allows the user to create widgets on the home screen so the user can call any Home Assistant service call. You can add the widget like you normally would for any app depending on your devices launcher. The widget will not work when Data Saver is enabled, you will also need to ensure that background data for the app is enabled.
-
-1.  Long press on any open space in the home screen
-2.  Scroll down to Home Assistant in the widget list
-3.  Drag the widget to an open space on the home screen
-4.  Select the service call you wish to perform
-5.  Fill in the required service data for the selected service call
-6.  Supply a name and icon for the widget
-7.  Save the widget

--- a/docs/core/android-widgets.md
+++ b/docs/core/android-widgets.md
@@ -1,0 +1,14 @@
+---
+title: "Android Widgets"
+id: 'android-widgets'
+---
+
+The ![android](/assets/android.svg) Android app allows the user to create widgets on the home screen so the user can call any Home Assistant service call. You can add the widget like you normally would for any app depending on your devices launcher. The widget will not work when Data Saver is enabled, you will also need to ensure that background data for the app is enabled. If you notice that a widget is no longer working try to recreate it.
+
+1.  Long press on any open space in the home screen
+2.  Scroll down to Home Assistant in the widget list
+3.  Drag the widget to an open space on the home screen
+4.  Select the service call you wish to perform
+5.  Fill in the required service data for the selected service call
+6.  Supply a name and icon for the widget
+7.  Save the widget

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -19,6 +19,16 @@ Not all features are supported by Android at the moment but eventually most feat
   </thead>
   <tbody>
     <tr>
+      <td><a href="/docs/core/actions">Actions</a></td>
+      <td></td>
+      <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="/docs/core/android-widgets">Android Widgets</a></td>
+      <td>✅</td>
+      <td></td>
+    </tr>
+    <tr>
       <td><a href="/docs/integrations/app-events">App Events</a></td>
       <td></td>
       <td>✅</td>
@@ -41,11 +51,6 @@ Not all features are supported by Android at the moment but eventually most feat
     <tr>
       <td><a href="/docs/integrations/universal-links">Universal Links</a></td>
       <td></td>
-      <td>✅</td>
-    </tr>
-    <tr>
-      <td><a href="/docs/core/actions#widgets">Widgets</a></td>
-      <td>✅</td>
       <td>✅</td>
     </tr>
     <tr>

--- a/sidebars.js
+++ b/sidebars.js
@@ -13,6 +13,7 @@ module.exports = {
     'Core Features': [
       'core/core',
       'core/actions',
+      'core/android-widgets',
       'core/location',
       'core/sensors'],
     'Notifications': [


### PR DESCRIPTION
Looks like this should've been in its own section as it is completely different than iOS Actions.