### PR TITLE
Update redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -21,6 +21,12 @@
   force = true
 
 [[redirects]]
+  from = "/docs/en/1.0.0/*"
+  to = "/docs/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/docs/en/*"
   to = "/docs/:splat"
   status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,6 +15,42 @@
   command = "yarn build"
 
 [[redirects]]
+  from = "/docs/en/core/index.html"
+  to = "/docs/core/core"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/en/getting_started/index.html"
+  to = "/docs/getting_started/getting-started"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/en/integrations/index.html"
+  to = "/docs/integrations/integrations"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/en/troubleshooting/setup.html"
+  to = "/docs/troubleshooting/faqs"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/en/troubleshooting/beta-cleaning.html"
+  to = "/docs/troubleshooting/resetting"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "/docs/en/troubleshooting/integrations.html"
+  to = "/docs/troubleshooting/troubleshooting-integrations"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/docs/en/next/*"
   to = "/docs/:splat"
   status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -15,6 +15,12 @@
   command = "yarn build"
 
 [[redirects]]
+  from = "/docs/en/next/*"
+  to = "/docs/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/docs/en/*"
   to = "/docs/:splat"
   status = 301


### PR DESCRIPTION
* Add redirect rule to catch against previous sites next version

* Redirect 1.0.0 docs. I hope no one was linking to these!

*In the migration to DSv2 we moved from using the file name in the url to the id. More accurately we defined an id which automatically became the URL. This was needed to ensure the sidebars worked well with the existing nested doc structure. These redirects address the changes so old links should still work. Redirectsto the next or 1.0.0 docs are handled by meeting the wild card rules first and then should be caught by the specific rule for that page (high priority)
