### PR TITLE
Fix notification examples

### DIFF
--- a/docs/notifications/attachments.md
+++ b/docs/notifications/attachments.md
@@ -14,18 +14,19 @@ It is important to note that the attachments are required to be accessible from 
 ![iOS](/assets/apple.svg) iOS Example
 
 ```yaml
-- alias: Notify Mobile app
-  trigger:
-    ...
-  action:
-    service: notify.mobile_app_<your_device_id_here>
-    data:
-      message: "Something happened at home!"
+automation:
+  - alias: Notify Mobile app
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
       data:
-        attachment:
-          url: "https://github.com/home-assistant/home-assistant-assets/blob/master/logo-round-192x192.png?raw=true"
-          content-type: png
-          hide-thumbnail: false
+        message: "Something happened at home!"
+        data:
+          attachment:
+            url: "https://github.com/home-assistant/home-assistant-assets/blob/master/logo-round-192x192.png?raw=true"
+            content-type: png
+            hide-thumbnail: false
 ```
 
 Notes:
@@ -36,15 +37,16 @@ Notes:
 ![android](/assets/android.svg) Android Example
 
 ```yaml
-- alias: Notify Mobile app
-  trigger:
-    ...
-  action:
-    service: notify.mobile_app_<your_device_id_here>
-    data:
-      message: "Something happened at home!"
+automation:
+  - alias: Notify Mobile app
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
       data:
-        image: "https://github.com/home-assistant/home-assistant-assets/blob/master/logo-round-192x192.png?raw=true"
+        message: "Something happened at home!"
+        data:
+          image: "https://github.com/home-assistant/home-assistant-assets/blob/master/logo-round-192x192.png?raw=true"
 ```           
 
 

--- a/docs/notifications/attachments.md
+++ b/docs/notifications/attachments.md
@@ -15,17 +15,17 @@ It is important to note that the attachments are required to be accessible from 
 
 ```yaml
 - alias: Notify Mobile app
-    trigger:
-      ...
-    action:
-      service: notify.mobile_app_<your_device_id_here>
+  trigger:
+    ...
+  action:
+    service: notify.mobile_app_<your_device_id_here>
+    data:
+      message: "Something happened at home!"
       data:
-        message: "Something happened at home!"
-        data:
-          attachment:
-            url: "https://github.com/home-assistant/home-assistant-assets/blob/master/logo-round-192x192.png?raw=true"
-            content-type: png
-            hide-thumbnail: false
+        attachment:
+          url: "https://github.com/home-assistant/home-assistant-assets/blob/master/logo-round-192x192.png?raw=true"
+          content-type: png
+          hide-thumbnail: false
 ```
 
 Notes:

--- a/docs/notifications/attachments.md
+++ b/docs/notifications/attachments.md
@@ -37,14 +37,14 @@ Notes:
 
 ```yaml
 - alias: Notify Mobile app
-    trigger:
-      ...
-    action:
-      service: notify.mobile_app_<your_device_id_here>
+  trigger:
+    ...
+  action:
+    service: notify.mobile_app_<your_device_id_here>
+    data:
+      message: "Something happened at home!"
       data:
-        message: "Something happened at home!"
-        data:
-          image: "https://github.com/home-assistant/home-assistant-assets/blob/master/logo-round-192x192.png?raw=true"
+        image: "https://github.com/home-assistant/home-assistant-assets/blob/master/logo-round-192x192.png?raw=true"
 ```           
 
 


### PR DESCRIPTION
Fix two indentation errors and also add `automation:` to top of examples to make it clear that that is where they are intended to be included