### PR TITLE
Added documentation on device_tracker attributes

### DIFF
--- a/docs/core/location.md
+++ b/docs/core/location.md
@@ -56,7 +56,7 @@ The newly created `device_tracker` entity may provide some of the following attr
 | speed             | meters/second |
 | vertical_accuracy | meters        |
 | floor             | floors  ![iOS](/assets/apple.svg)      |
-| timestamp         | Date          |
+| timestamp         | Date    ![iOS](/assets/apple.svg)      |
 
 If you want to know more about the specifics of these attributes, please refer to the relevant documentation of your operating system:
 

--- a/docs/core/location.md
+++ b/docs/core/location.md
@@ -55,7 +55,7 @@ The newly created `device_tracker` entity may provide some of the following attr
 | course            | degrees       |
 | speed             | meters/second |
 | vertical_accuracy | meters        |
-| floor             | floors        |
+| floor             | floors  ![iOS](/assets/apple.svg)      |
 | timestamp         | Date          |
 
 If you want to know more about the specifics of these attributes, please refer to the relevant documentation of your operating system:

--- a/docs/core/location.md
+++ b/docs/core/location.md
@@ -43,6 +43,27 @@ automation:
           entity_id: light.frontdoor
 ```
 
+## Entity attributes
+The newly created `device_tracker` entity may provide some of the following attributes depending on your operating system.
+
+| Name              | Unit          |
+|-------------------|---------------|
+| latitude          | degrees       |
+| longitude         | degrees       |
+| gps_accuracy      | meters        |
+| altitude          | meters        |
+| course            | degrees       |
+| speed             | meters/second |
+| vertical_accuracy | meters        |
+| floor             | floors        |
+| timestamp         | Date          |
+
+If you want to know more about the specifics of these attributes, please refer to the relevant documentation of your operating system:
+
+[Android](https://developer.android.com/reference/android/location/Location) or
+[iOS](https://developer.apple.com/documentation/corelocation/cllocation)
+
+
 ## Location tracking when outside a Home Assistant zone
 
 ![iOS](/assets/apple.svg)

--- a/docs/core/location.md
+++ b/docs/core/location.md
@@ -48,15 +48,16 @@ The newly created `device_tracker` entity may provide some of the following attr
 
 | Name              | Unit          |
 |-------------------|---------------|
-| latitude          | degrees       |
-| longitude         | degrees       |
-| gps_accuracy      | meters        |
-| altitude          | meters        |
-| course            | degrees       |
-| speed             | meters/second |
-| vertical_accuracy | meters        |
-| floor             | floors  ![iOS](/assets/apple.svg)      |
-| timestamp         | Date    ![iOS](/assets/apple.svg)      |
+| `source`   |  _None_  |
+| `battery_level`  |  percentage  |
+| `latitude`          | degrees       |
+| `longitude`         | degrees       |
+| `gps_accuracy`      | meters        |
+| `altitude`          | meters        |
+| `course`            | degrees       |
+| `speed`             | meters per second |
+| `vertical_accuracy` | meters        |
+| `floor`             | floors  ![iOS](/assets/apple.svg)      |
 
 If you want to know more about the specifics of these attributes, please refer to the relevant documentation of your operating system:
 

--- a/docs/core/location.md
+++ b/docs/core/location.md
@@ -64,7 +64,6 @@ If you want to know more about the specifics of these attributes, please refer t
 [Android](https://developer.android.com/reference/android/location/Location) or
 [iOS](https://developer.apple.com/documentation/corelocation/cllocation)
 
-
 ## Location tracking when outside a Home Assistant zone
 
 ![iOS](/assets/apple.svg)


### PR DESCRIPTION
Since I was confused about what unit the `speed` value might be, I've updated the documentation according to the current code.

There might be iOS device things missing since I don't own any. Please check

I've used the code as a reference
https://github.com/home-assistant/home-assistant-iOS/blob/396f82c5f25b9a4d28790f8382aa3f09ef86aedd/Shared/API/Models/DeviceTrackerSee.swift#L126