### PR TITLE
Clarify that only iOS shows the rate limit in app

### DIFF
--- a/docs/notifications/details.md
+++ b/docs/notifications/details.md
@@ -16,7 +16,7 @@ To provide the notification service, the app uses Google's Firebase cloud messag
 
 Currently, you are allowed to send a maximum of 150 push notifications per day per device. The rate limit resets at midnight UTC daily. This is to ensure that the service remains cheap to maintain. In the future we may add support for upgrading to allow more notifications.
 
-The in-app Notifications settings screen in the iOS app displays your current rate limits for the day broken out into the following categories: Attempts, Delivered, Errors, Total, and the exact time until next daily reset. For Android you can see the rate limit in the logs, you will need to set `homeassistant.components.mobile_app.notify: info` for the [`logger`](https://www.home-assistant.io/integrations/logger/) integration.
+The in-app Notifications settings screen in the iOS app displays your current rate limits for the day broken out into the following categories: Attempts, Delivered, Errors, Total, and the exact time until next daily reset. For Android you can see the rate limit in the logs, depending on your configuration you may need to set `homeassistant.components.mobile_app.notify: info` for the [`logger`](https://www.home-assistant.io/integrations/logger/) integration.
 
 If an error occurs while sending a notification, it does not count towards your rate limit. Critical Alerts, Requesting location updates [via push notiifcation](notifications/location.md) and the special `clear_badge` or `clear_notification` notification type also do not count towards your rate limit.
 

--- a/docs/notifications/details.md
+++ b/docs/notifications/details.md
@@ -14,12 +14,11 @@ To provide the notification service, the app uses Google's Firebase cloud messag
 
 ## Rate limiting
 
-Currently, you are allowed to send a maximum of 150 push notifications per day per device. This is to ensure that the service remains cheap to maintain. In the future we may add support for upgrading to allow more notifications.
+Currently, you are allowed to send a maximum of 150 push notifications per day per device. The rate limit resets at midnight UTC daily. This is to ensure that the service remains cheap to maintain. In the future we may add support for upgrading to allow more notifications.
 
-The in-app Notifications settings screen displays your current rate limits for the day broken out into the following categories: Attempts, Delivered, Errors, Total, and the exact time until next daily reset. The rate limit resets at midnight UTC daily.
+![iOS](/assets/apple.svg) The in-app Notifications settings screen in the iOS app displays your current rate limits for the day broken out into the following categories: Attempts, Delivered, Errors, Total, and the exact time until next daily reset.
 
-If an error occurs while sending a notification, it does not count towards your rate limit. Critical Alerts, Requesting location updates [via push notiifcation](notifications/location.md) and the special `clear_badge` notification type also do not count towards your rate limit.
-
+If an error occurs while sending a notification, it does not count towards your rate limit. Critical Alerts, Requesting location updates [via push notiifcation](notifications/location.md) and the special `clear_badge` or `clear_notification` notification type also do not count towards your rate limit.
 
 
 ## Security

--- a/docs/notifications/details.md
+++ b/docs/notifications/details.md
@@ -16,7 +16,7 @@ To provide the notification service, the app uses Google's Firebase cloud messag
 
 Currently, you are allowed to send a maximum of 150 push notifications per day per device. The rate limit resets at midnight UTC daily. This is to ensure that the service remains cheap to maintain. In the future we may add support for upgrading to allow more notifications.
 
-![iOS](/assets/apple.svg) The in-app Notifications settings screen in the iOS app displays your current rate limits for the day broken out into the following categories: Attempts, Delivered, Errors, Total, and the exact time until next daily reset.
+![iOS](/assets/apple.svg) The in-app Notifications settings screen in the iOS app displays your current rate limits for the day broken out into the following categories: Attempts, Delivered, Errors, Total, and the exact time until next daily reset. You can also see the rate limit in the logs, you will need to set `homeassistant.components.mobile_app.notify: info` for the [`logger`](https://www.home-assistant.io/integrations/logger/) integration.
 
 If an error occurs while sending a notification, it does not count towards your rate limit. Critical Alerts, Requesting location updates [via push notiifcation](notifications/location.md) and the special `clear_badge` or `clear_notification` notification type also do not count towards your rate limit.
 

--- a/docs/notifications/details.md
+++ b/docs/notifications/details.md
@@ -16,7 +16,7 @@ To provide the notification service, the app uses Google's Firebase cloud messag
 
 Currently, you are allowed to send a maximum of 150 push notifications per day per device. The rate limit resets at midnight UTC daily. This is to ensure that the service remains cheap to maintain. In the future we may add support for upgrading to allow more notifications.
 
-![iOS](/assets/apple.svg) The in-app Notifications settings screen in the iOS app displays your current rate limits for the day broken out into the following categories: Attempts, Delivered, Errors, Total, and the exact time until next daily reset. You can also see the rate limit in the logs, you will need to set `homeassistant.components.mobile_app.notify: info` for the [`logger`](https://www.home-assistant.io/integrations/logger/) integration.
+The in-app Notifications settings screen in the iOS app displays your current rate limits for the day broken out into the following categories: Attempts, Delivered, Errors, Total, and the exact time until next daily reset. For Android you can see the rate limit in the logs, you will need to set `homeassistant.components.mobile_app.notify: info` for the [`logger`](https://www.home-assistant.io/integrations/logger/) integration.
 
 If an error occurs while sending a notification, it does not count towards your rate limit. Critical Alerts, Requesting location updates [via push notiifcation](notifications/location.md) and the special `clear_badge` or `clear_notification` notification type also do not count towards your rate limit.
 


### PR DESCRIPTION
Reword things a little bit as only the iOS app shows the rate limit.  Android users will need to view the logs to see the limit.