### PR TITLE
Add info about android notification channels

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -137,6 +137,11 @@ Not all features are supported by Android at the moment but eventually most feat
       <td>✅</td>
     </tr>
     <tr>
+      <td><a href="/docs/notifications/notifications-basic#notification-channels">Channels</a></td>
+      <td>✅</td>
+      <td></td>
+    </tr>
+    <tr>
       <td><a href="/docs/notifications/notifications-basic#notification-click-action">Click Action</a></td>
       <td>✅</td>
       <td></td>

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -197,7 +197,7 @@ automation:
 ![android](/assets/android.svg)
 In Android you can set the `color` of the notification, you can use either the color name or the hex code.
 
-```
+```yaml
 automation:
   - alias: Notify of Motion
     trigger:
@@ -216,7 +216,7 @@ automation:
 ![android](/assets/android.svg)
 You can set whether to dismiss the notification upon selecting it or not. Setting `sticky` to `'true'` will keep the notification from being dismissed when the user selects it. Setting it to `'false'` (default) will dismiss the notification upon selecting it.
 
-```
+```yaml
 automation:
   - alias: Notify of Motion
     trigger:
@@ -235,7 +235,7 @@ automation:
 ![android](/assets/android.svg)
 When a notification is selected the user can either be navigated to a specific lovelace view or you can have a webpage open to any URL. If you plan to use a lovelace view the format would be `/lovelace/test` where `test` is replaced by your defined [`path`](https://www.home-assistant.io/lovelace/views/#path) in the defined view. The default behavior is to just open the Home Assistant app.
 
-```
+```yaml
 automation:
   - alias: Notify of Motion
     trigger:
@@ -247,4 +247,42 @@ automation:
         message: "Someone might be in the backyard."
         data:
           clickAction: 'https://google.com' # action when clicking main notification
+```
+
+### Notification Channels
+
+![android](/assets/android.svg)
+Notification channels allows users to separate their notifications easily (i.e. alarm vs laundry) so they can customize aspects like what type of sound is made and a lot of other device specific features. Devices running Android 8.0+ are able to create and manage notification channels on the fly using automations. Once a channel is created you can navigate to your notification settings and you will find the newly created channel, from there you can customize the behavior based on what your device allows.
+
+In order to create a notification you will need to specify the `channel` you wish to use. By default all notifications use `Default Channel` if `channel` is not defined.
+
+In the example below a new channel will be created with the name `Motion`:
+
+```yaml
+automation:
+  - alias: Notify of Motion
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
+      data:
+        title: "Motion Detected in Backyard"
+        message: "Someone might be in the backyard."
+        data:
+          channel: Motion # name of the channel you wish to create or utilize
+```
+
+If you wish to remove a channel you will need to send `remove_channel` with the `channel` you wish to remove:
+
+```yaml
+automation:
+  - alias: Notify of Motion
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
+      data:
+        message: remove_channel
+        data:
+          channel: Motion # name of the channel you wish to remove
 ```

--- a/docs/notifications/details.md
+++ b/docs/notifications/details.md
@@ -18,7 +18,7 @@ Currently, you are allowed to send a maximum of 150 push notifications per day p
 
 The in-app Notifications settings screen in the iOS app displays your current rate limits for the day broken out into the following categories: Attempts, Delivered, Errors, Total, and the exact time until next daily reset. For Android you can see the rate limit in the logs, depending on your configuration you may need to set `homeassistant.components.mobile_app.notify: info` for the [`logger`](https://www.home-assistant.io/integrations/logger/) integration.
 
-If an error occurs while sending a notification, it does not count towards your rate limit. Critical Alerts, Requesting location updates [via push notiifcation](notifications/location.md) and the special `clear_badge` or `clear_notification` notification type also do not count towards your rate limit.
+If an error occurs while sending a notification, it does not count towards your rate limit. Critical Alerts, Requesting location updates [via push notification](notifications/location.md) and the special `clear_badge`, `clear_notification` or `remove_channel` notification messages also do not count towards your rate limit.
 
 
 ## Security


### PR DESCRIPTION
Since https://github.com/home-assistant/android/pull/574 was merged its time to add some information about how users can utilize the new feature.

Also added some missing `yaml` statements and fixed a small typo.

CC: @CraftyKoala & @jbassett