### PR TITLE
Fix event trigger link on the URL handler documentation page

### DIFF
--- a/docs/integrations/url-handler.md
+++ b/docs/integrations/url-handler.md
@@ -13,7 +13,7 @@ Query parameters are passed as a dictionary in the call.
 Example: `homeassistant://call_service/device_tracker.see?entity_id=device_tracker.entity`
 
 ## Fire event
-You can create an [event trigger](/docs/automation/trigger/#event-trigger) and fire the event.
+You can create an [event trigger](https://www.home-assistant.io/docs/automation/trigger/#event-trigger) and fire the event.
 
 Example: `homeassistant://fire_event/custom_event?entity_id=MY_CUSTOM_EVENT`
 


### PR DESCRIPTION
This pull request proposes that the link to the event trigger URL be changed from [https://companion.home-assistant.io/docs/automation/trigger/#event-trigger](/docs/automation/trigger/#event-trigger) to [https://www.home-assistant.io/docs/automation/trigger/#event-trigger](https://www.home-assistant.io/docs/automation/trigger/#event-trigger). The old URL points to a 404 and this new link within the Home Assistant documentation seems to be where that document has been moved to.