### PR TITLE
Standardise heading levels

### DIFF
--- a/docs/core/actions.md
+++ b/docs/core/actions.md
@@ -7,7 +7,7 @@ id: 'actions'
 
 Actions is a generic system that allows you to easily integrate the Home Assistant automations system into multiple areas of iOS and [Apple Watch](../integrations/watch/index.md).
 
-# Creating Actions
+## Creating Actions
 Actions are created from the Actions section of the App Configuration page within the companion App for iOS. Each action has required fields depending on your device:
 *   `Name`: the name of the action, this will be returned in the [Home Assistant event](https://www.home-assistant.io/docs/configuration/events/) fired by the app.
 *   `Text`: the descriptive text shown on the phone and watch. It is best to keep this relatively short as there is limited space on each action's button.
@@ -18,7 +18,7 @@ Actions are created from the Actions section of the App Configuration page withi
 
 For the three color fields, the color is selected by tapping the color-picker circle in each field.
 
-# Using Actions
+## Using Actions
 When an action button is pressed a `ios.action_fired` event is fired on Home Assistant's event bus. The event data consists of a JSON-formatted dictionary of attributes relating to the action.
 
 | Attribute | Value |
@@ -69,14 +69,14 @@ Note that attributes located in the `data` and `context` are accessed through `e
 
 You can use the Events page within Home Assistant's developer tools to show all information contained with the event for a particular event by subscribing to `ios.action_fired` and triggering the action from you device.
 
-# Apple Watch
+## Apple Watch
 The [Apple Watch App](integrations/watch/index.md) provides access to actions you have created. Once you have created an action within the Actions page, open the Home Assistant watch and the action list should sync.
 
 
-# Home Screen Quick Actions
+## Home Screen Quick Actions
 [Home Screen Quick Actions](https://support.apple.com/guide/iphone/keep-apps-handy-iph414564dba/ios#iph1ffcbd691) provides a convenient shortcut to your actions and is accessed by 3D Touching the Home Assistant companion app icon on your home screen.
 
-# Today View Widget
+## Today View Widget
 The [Today View Widget](https://support.apple.com/en-gb/HT207122) is another route through which actions can be fired. To add the Home Assistant widget to your Today View:
 
 1.  Swipe right while on the Home screen or Lock screen.

--- a/docs/getting_started/migration.md
+++ b/docs/getting_started/migration.md
@@ -8,7 +8,7 @@ id: migration
 
 The steps below should guide you through the process of migrating from the previous app version (1.5) to 2019.1. Before going any further, please make sure you read the [breaking changes](#breaking-changes) listed below.
 
-# Breaking Changes
+## Breaking Changes
 -   All notifications need to be updated as the notify service is moving from `notify.ios_<device_id>` to `notify.mobile_app_<device_name>`. In the old version the `device_id` was set in the iOS app settings, after the update the `device_name` is taken from iOS settings (see iOS Settings App>General>About).
 -   Your existing device tracker entity will be obsolete. The old app used `known_devices.yaml` whereas the updated app uses the `mobile_app` integration and entity storage. Your old tracker `device_tracker.device_id` will no longer update, the new tracker will be called `device_tracker.device_name`.
 -   The new device tracker no longer contains attributes such as "trigger: Geographic Region entered". These have all moved to sensors that will be created via the `mobile_app` integration.
@@ -17,7 +17,7 @@ The steps below should guide you through the process of migrating from the previ
 -   The send manual location update button has been removed along with the footer bar. You can now send an update manually be pulling/swiping down within the app. This will refresh the page and also send a location update. You can also send a location update by tap-and-holding the app icon.
 -   The `group.all_devices` group was maintained by the now legacy `device_tracker` service based on `known_devices.yaml` used by the `ios` integration. Since this is no longer used, device running 2019.1 will not be added to the `group.all_devices`. The new `device_tracker` entities can be associated with `person` entities however which can be grouped in a similar way.
 
-# Requirements
+## Requirements
 You need to be running Home Assistant 0.95.0 or newer. The new updated iOS app requires the following integrations to be enabled in your Home Assistant instance:
 -   `default_config:`
 
@@ -29,10 +29,10 @@ For some features the following integrations also need to be enabled:
 -   `cloud:` is used for securely connecting to your Home Assistant via Nabu Casa subscription via Remote UI and cloud webhooks
 -   `ios:` is used if you want advanced notifications like actionable notifications and categories
 
-# Updating from Home Assistant Companion 1.5
+## Updating from Home Assistant Companion 1.5
 First, apologies for the breaking changes and associated manual steps required. We have provided this guide to help you get through any issues as quickly as possible so you can enjoy the new app experience!
 
-## 1 - Updating the iOS app via the App Store
+### 1 - Updating the iOS app via the App Store
 Given the default settings, this may already have happened to you and your app will have auto-updated via the iOS Store. If not, manually update the app and open it.
 -   You will be greeted by the new onboarding experience. If you are connected to your home Wi-Fi, the app will find your Home Assistant instance - or you can manually enter the URL.
 -   You will be prompted to log on to your Home Assistant instance.
@@ -47,11 +47,11 @@ Given the default settings, this may already have happened to you and your app w
 
 An illustrated description of the onboarding process can be found in the [main guide](index).
 
-## 2 - Updating notifications and device trackers
+### 2 - Updating notifications and device trackers
 Because the app is using a new push notification backend and the new device tracker architecture, you will need to change your automations to use the new service and tracker:
 -   Update your automations and configuration files (e.g. `configuration.yaml` and additional files you may have set up) to use the new service and `device_tracker` entity. This should be as simple as using search & replace with your old and new service and entity names.
 
-## 3 - Cleanup of the old iOS integration
+### 3 - Cleanup of the old iOS integration
 
 Your iOS devices are all updated and you're up and running with the new and shiny? Great! Now it's time to clean up and get rid of the now obsolete old entries.
 1.  Use a browser to load your Home Assistant instances and go to "Configuration" (cog icon) and then "Integrations".
@@ -61,7 +61,7 @@ Your iOS devices are all updated and you're up and running with the new and shin
 5.  Open the `known_devices.yaml` file and remove the entry that has the same `<device_name>` as in Step 3.
 6.  Restart Home Assistant. The connection between your old Home Assistant Companion 1.5 App and your Home Assistant Instance should now be fully removed.
 
-## 4 - Common problems
+### 4 - Common problems
 -   During onboarding when entering the username and password, you may get an error message and Home Assistant logs
 `[homeassistant.components.auth.indieauth] Timeout while looking up redirect_uri https://home-assistant.io/iOS`: This happens when your Home Assistant (and likely your home network) has a broken IPv6 configuration. This usually can be resolved by fixing the IPv6 on your network or disabling IPv6 on your Home Assistant host system. This is not a bug in the app.
 -   If you receive a 405 error code when trying to sign in after the app auto discovered your Home Assistant instance, try manually entering the address of you Home Assistant instance instead.
@@ -82,7 +82,7 @@ Your iOS devices are all updated and you're up and running with the new and shin
     And one or both of `mobile_app` or `cloud` listed. This is most common when you have Home Assistant installed on top of an operating system that isn't HassOS and contains out of date dependancies. To fix this, please check all your libraries are up to date (specifically `libc6 `).
 -   Your `sensor.SSID` and `senson.BSSID` entities are not updating and/or your app does not switch to using an internal URL when on your home Wi-Fi. You can fix both of these issue by restarting your device.
 
-## 5 - Known issues
+### 5 - Known issues
 -   All sensors created during onboarding are only called e.g. `sensor.battery_level`. If you have multiple iOS devices you may have multiple similarly named entities. If needed, you can rename the entities via Home Assistant Configuration (cog icon on sidebar) -> Integrations -> Mobile App: iOS Device Name and prefixing the sensors with the device name. This may get resolved with future updates to the `mobile_app` integration.
 -   Due to issues between China and Google Cloud Services registering the notify service from China can be hit or miss. A workaround will be added in a future update, until then please try using a VPN to tunnel outside the Great Firewall.
 -   iOS Location Permissions are required for the app to use Internal_URL / External_URL on iOS 13 and newer. This is due to a change in iOS which prohibits the app to access the Wi-Fi SSID name.

--- a/docs/integrations/siri-shortcuts.md
+++ b/docs/integrations/siri-shortcuts.md
@@ -5,9 +5,9 @@ id: siri-shortcuts
 
 With iOS 12 or later, you can take advantage of the power of Siri Shortcuts to carry out Home Assistant tasks with a tap or by using voice commands.
 
-# Actions
+## Actions
 
-## Call Service
+### Call Service
 You can call any service that shows up in the "Services" page <img src="https://www.home-assistant.io/images/screenshots/developer-tool-services-icon.png" width="24" height="24" /> of Home Assistant.
 
 As an example, if you wanted to start your bedtime routine automation you would do the following:
@@ -22,20 +22,20 @@ As an example, if you wanted to start your bedtime routine automation you would 
 It's that easy! Now when you say "Hey Siri, it's bedtime" Siri will trigger your bedtime routine automation without you even having to lift a finger.
 
 
-## Fire Event
+### Fire Event
 
 > Must be valid JSON. If no payload is provided, clipboard contents will be used.
 
-## Get Camera Snapshot
+### Get Camera Snapshot
 Get a single still frame from the entity ID found on the clipboard and place it on the clipboard.
 
-## Render Template
+### Render Template
 Render text found on the clipboard.
 
-## Send Location
+### Send Location
 Send a location to Home Assistant. Will attempt to use clipboard contents as location, otherwise will use current location.
 
-# Using Shortcuts
+## Using Shortcuts
 
 You can send a special push notification to your device, that when tapped, will open the Shortcut of your choosing and run it. Here's an example payload:
 

--- a/docs/troubleshooting/errors.md
+++ b/docs/troubleshooting/errors.md
@@ -5,24 +5,24 @@ id: 'errors'
 
 Here's a list of all the error codes you may experience with further documentation about why this happens and what to do about it.
 
-# Setup and Connectivity
+## Setup and Connectivity
 
-## "Invalid Client ID or Redirect URI"  and  "OS Error while looking up redirect_uri"
+### "Invalid Client ID or Redirect URI"  and  "OS Error while looking up redirect_uri"
 Check your `home-assistant.log` file for any errors about `indieauth`. If it also mentions a OS Error, you most likely have a broken IPv6 implementation. You can confirm this by running `curl -v6 https://home-assistant.io/iOS/beta-auth` from the machine you run Home Assistant on. If you receive a error about not being able to connect to the server, your IPv6 stack is broken and you should disable it.
 
-## "Invalid Client ID or Redirect URI"  and  "Timeout while while looking up redirect_uri"
+### "Invalid Client ID or Redirect URI"  and  "Timeout while while looking up redirect_uri"
 Check your `home-assistant.log` file for any errors about `indieauth`. If it also mentions a Timeout, you may have a problem with your DNS not behaving as expected. You can confirm this by running `dig home-assistant.io` and `nslookup home-assistant.io` from the machine you run Home Assistant on. If you see any errors there could be a dns problem.
 
 Fixing this varies depending on your setup - but it's worth trying the google dns servers `8.8.8.8` and `1.1.1.1`. If you are running a hassOS setup you can do this with `ha dns options --servers dns://8.8.8.8 --servers dns://1.1.1.1`.
 
-## SSL error while looking up redirect_uri <https://home-assistant.io/iOS>
+### SSL error while looking up redirect_uri <https://home-assistant.io/iOS>
 This error means that your Home Assistant can't negotiate the encrypted connection to <https://home-assistant.io>. This issue has been seen on installations running on top of MacOS where the installer notice about certificates was skipped and ignored. From the Python 3.7.5 ReadMe:
 
 >Certificate verification and OpenSSL
 >This package includes its own private copy of OpenSSL 1.1.1.   The trust certificates in system and user keychains managed by the Keychain Access application and the security command line utility are not used as defaults by the Python `ssl` module.  A sample command script is included in `/Applications/Python 3.7` to install a curated bundle of default root certificates from the third-party certifi package (<https://pypi.org/project/certifi/>).  Double-click on `Install Certificates` to run it.
 >The bundled pip has its own default certificate store for verifying download connections.
 
-## "Setup failed for dependencies: `zeroconf`"
+### "Setup failed for dependencies: `zeroconf`"
 This error is usually caused by one of the two following issues:
 *   You are running two Home Assistant instances with identical names. The solution is to rename one of them.
 *   You are missing `default_config:` from your `configuration.yaml` file. It is possible to only add `zeroconf:` to `configuration.yaml` but adding `default_config:` will add [several useful integrations](https://www.home-assistant.io/components/default_config/) along with `zeroconf:`.

--- a/docs/troubleshooting/setup.md
+++ b/docs/troubleshooting/setup.md
@@ -5,7 +5,7 @@ id: 'faqs'
 
 Below is a list of common issues and troubleshooting advice to address them. For more support please [look at the more help page](more-help.md)
 
-#### App crashes on set up
+## App crashes on set up
 
 If you are running Home Assistant 0.110 and the app crashes after clicking "continue" during set up, you need to add values for `internal_url` and `external_url`. This can be done through the user interface (Configuration>General). If these fields are disabled it is likely you have have your configuration stored in `configuration.yaml`, in this case add the entries under `homeassistant:` i.e.:
 
@@ -20,14 +20,14 @@ Replacing `URL` with the address you use to access your Home Assistant instance.
 
 When you have saved these changes, restart Home Assisant and, after Home Assistant has finished restarting, reopen the the app. 
 
-#### I don't see a `notify.mobile_app` service for my device in my `dev-services` panel
+## I don't see a `notify.mobile_app` service for my device in my `dev-services` panel
 Once you have [set up](/getting_started/index.md) the Companion app you will need to restart Home Assistant for the `notify.mobile_app` service call to register. On iOS the `notify.mobile_app_<Device_ID>` service will be created provided you granted notification permissions during setup, on Android the service call will appear after the restart. If you can't see this, [force quit on iOS](https://support.apple.com/HT201330) or force stop on Android. Then relaunch the Companion app and finally restart your Home Assistant instance. The service should now be listed in the `Developer Tools > Services` panel.
 
 ![iOS](/assets/apple.svg) If you don't see the service call on iOS, check the notification settings within the app (swipe right to bring up the sidebar, the tap "App Configuration", then "Notifications"). If the "Push ID" box is empty, tap the Reset button below it.
 
 ![android](/assets/android.svg) If you still don't see the service call on Android follow the steps to [start fresh](#starting-fresh-with-the-android-app).
 
-#### I have a `notify.mobile_app_<Device_ID>` service but don't receive notifications
+## I have a `notify.mobile_app_<Device_ID>` service but don't receive notifications
 Firstly, check your message payload is valid. Look at the examples in the [notification docs](../notifications/basic.md) or try sending the simple example below on the `Developer Tools > Services` page to your `notify.mobile_app_<Device_ID>` service.
 ```JSON
 {"message": "Hello World"}
@@ -45,22 +45,22 @@ If the above doesn't work, try the following:
 
 4. _Start fresh with the Android app:_ ![android](/assets/android.svg) If you still can't recieve notifications in the Android app then try to [start fresh](#starting-fresh-with-the-android-app).
 
-#### I receive an SSL error and/or I am unable to connect to my Home Assistant Instance when away from Home
+## I receive an SSL error and/or I am unable to connect to my Home Assistant Instance when away from Home
 This often happens when you have the [Home Assistant Cloud](https://www.home-assistant.io/cloud/) enabled but have do not have [Remote UI](https://www.nabucasa.com/config/remote/) turned on. To address this either enable the [Remote UI](https://www.nabucasa.com/config/remote/) or swipe right to open the sidebar and the tap "App Configuration" then under "Settings" tap "Connection". Make sure the switch next to "Connect Via Cloud" is off and enter the remote address of your Home Assistant Instance in the "External URL" field. This address must be for an encrypted connection, for instructions on setting up an encrypted remote connection to your Home Assistant instances, please see the [Home Assistant docs](https://www.home-assistant.io/docs/configuration/remote/) or [this guidde to setting up Let's Encrypt with Duck DNS](https://www.home-assistant.io/docs/ecosystem/certificates/lets_encrypt/).
 
 If you do not have [Home Assistant Cloud](https://www.home-assistant.io/cloud/) set up at all, the problem is likely that the remote connection is not secured. The Companion App requires an encrypted connection for remote connections. Please see the [Home Assistant docs](https://www.home-assistant.io/docs/configuration/remote/) or [this guide to setting up Let's Encrypt with Duck DNS](https://www.home-assistant.io/docs/ecosystem/certificates/lets_encrypt/) for instructions on setting up a secured connection.
 
-#### Something in Home Assistant doesn't work the same way it does on my desktop
+## Something in Home Assistant doesn't work the same way it does on my desktop
 This is probably not an issue with the Companion App but more likely with Home Assistant or the particular component that isn't behaving as expected. To test the cause please try the following steps.
 
 1.  Firstly, swipe down in the iOS Companion app to refresh your view. In the Android app force stop the application and relaunch it.
 2.  If the problem still persists, open your Home Assistant instance in the Safari/Chrome browser (you may have to sign in). If the problem is present in Safari/Chrome, please raise an issue on either the [Home Assistant Frontend GitHub](https://github.com/home-assistant/frontend/issues) or if it is with a custom component, with the developer of that component. In your issue report, state that the problem exists when viewing on a mobile browser and not necessarily the Companion App.
 3.  If the problem does not occur in Safari, please raise an issue on the [iOS Companion App GitHub](https://github.com/home-assistant/iOS/issues) or the [Android Companion App GitHub](https://github.com/home-assistant/android/issues). Please state you followed these steps and the problem only occurs in the Companion app.
 
-#### The status bar (top bar with cell/Wi-Fi strength) does not match my theme
+## The status bar (top bar with cell/Wi-Fi strength) does not match my theme
 To change the color of the status bar to match your Home Assistant theme, please use the [`frontend.set_theme`](https://www.home-assistant.io/components/frontend/#theme-automation) service instead of the dropdown menu in the Home Assistant profile page. Using the service will generate an event allowing the Companion App to detect the theme change and apply the correct color to the status bar. See the [theming](../integrations/theming.md) documentation for details of which keys are used. Note that colors must be specified as hex values (e.g. `#0099ff`) in your theme and specifying element colors through variable names is not supported.
 
-#### I am running the Companion App on multiple devices, the `sensor` names are too similar and confusing, what can I do?
+## I am running the Companion App on multiple devices, the `sensor` names are too similar and confusing, what can I do?
 Starting in Home Assistant Core 0.106, the default sensor names will be registered with your device name as set in the iOS settings app or the Android App Configuration page. For now, you will need to rename each sensor from within the Integrations section of Home Assistant's Configuration page by following these steps.
 
 1.  Open the Home Assistant "Configuration" page from the sidebar (if using the app, swipe right to access this)
@@ -71,13 +71,13 @@ Starting in Home Assistant Core 0.106, the default sensor names will be register
 6.  Repeat Steps 4 and 5 for each sensor you wish to rename
 
 
-#### Opening or resuming the Companion App generates authentication errors in my Home Assistant notifications
+## Opening or resuming the Companion App generates authentication errors in my Home Assistant notifications
 This is normally due to having a camera entity present on a Lovelace picture entities or picture elements card. A workaround for this is to remove the the camera entity in the short term while this is resolved. You may be able to use [live stream view](https://github.com/home-assistant/core/issues/23055) to address this. This is a known bug with Home Assistant which you can track and help address [here](https://github.com/home-assistant/core/issues/23055).
 
-#### I recieve a `kCLError` when pulling down to manually refresh the app/update Location
+## I recieve a `kCLError` when pulling down to manually refresh the app/update Location
 To fix this change the location permission for the Home Assistant App to "Always" in iOS Settings>Privacy>Location Services.
 
-#### Starting fresh with the Android app
+## Starting fresh with the Android app
 At times you may need to start fresh with the Android app as a new feature may not be working properly or something odd happens.
 
 1.  Check that Home Assistant Core and the Android app are up to date.
@@ -87,7 +87,7 @@ At times you may need to start fresh with the Android app as a new feature may n
 5.  Log back into Android app. If you have more than 1 device make sure to rename the device under App Configuration.
 6.  Restart Home Assistant once more to register the `notify.mobile_app` service call.
 
-#### Location is not updating in Android app
+## Location is not updating in Android app
 If you find that location updates are not coming in here are a few things to check.
 
 1.  Ensure the app has location permissions granted, all the time.
@@ -95,22 +95,22 @@ If you find that location updates are not coming in here are a few things to che
 3.  Ensure that the location toggles are enabled in App Configuration in the Android app.
 4.  Turn on unrestricted data for the Android app.
 
-#### Using a self-signed certificate leads to a blank page in Android
+## Using a self-signed certificate leads to a blank page in Android
 If you are using a self-signed certificate on Android then you may get stuck at a blank screen after entering and/or selecting your Home Assistant instance. In order to correct this issue you will need to make sure the URL is valid and that you import the certificate into Android's Trusted Certificates. Steps to perform this can be found [here](https://support.google.com/nexus/answer/2844832?hl=en). These steps were written for devices on Android 9+ but are very close for older supported devices.
 
-#### Android widget is not working
+## Android widget is not working
 If you find that a widget is no longer working then these steps may help you resolve the issue.
 
 1.  Check that data saver is disabled on the device, the widget will not work when it is enabled.
 2.  Check that background data for the Home Assistant app is enabled.
 3.  Remove and recreate the widget.
 
-#### Notify service call is too similar or not showing up in Android
+## Notify service call is too similar or not showing up in Android
 If you have more than 1 device of the same model and you did not rename your device in App Configuration after logging in then you may have a conflict.
 
 1.  Navigate to App Configuration in the sidebar.
 2.  Change the Device Name under Device Registration.
 3.  Restart Home Assistant to register the new notify service call. (i.e. `notify.mobile_app_<device_name>`)
 
-#### Sensors are missing or not updating
+## Sensors are missing or not updating
 Sensors are tied to location updates so you will need to make sure that location is enabled for the device and app in order for sensor updates to be sent to the phone. Once you enable location for the app the sensors will show up and continue to update as long as location is enabled on the device and app.


### PR DESCRIPTION
We had a bit of a mix of heading levels going on across the docs. I've tried to tidy that up. We should avoid using the `#`/`H1` level as this is the same level used with the `title` property from the meta data
