### PR TITLE
Add Android-only icon against clear_notification

### DIFF
--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -133,6 +133,7 @@ automation:
           tag: tag
 ```
 
+![android](/assets/android.svg)
 You can also remove a notification by sending `clear_notification` to the same `tag`
 
 ```yaml


### PR DESCRIPTION
It was mentioned in home-assistant/ios#587 that the docs are not clear that `clear_notification` is android only. Added the icon against that line
