### PR TITLE
Lots of new android notification improvements

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -162,14 +162,44 @@ Not all features are supported by Android at the moment but eventually most feat
       <td>✅</td>
     </tr>
     <tr>
+      <td><a href="/docs/notifications/notifications-basic#notification-grouping">Grouping</a></td>
+      <td>✅</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td><a href="/docs/notifications/notifications-basic#notification-message-html-formatting">HTML Formatting</a></td>
+      <td>✅</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td><a href="/docs/notifications/notifications-basic#notification-icon">Icon</a></td>
+      <td>✅</td>
+      <td></td>
+    </tr>
+    <tr>
       <td><a href="/docs/notifications/notification-attachments">Image</a></td>
       <td>✅</td>
       <td>✅</td>
     </tr>
     <tr>
+      <td><a href="/docs/notifications/notifications-basic#notification-channel-importance">Importance</a></td>
+      <td>✅</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td><a href="/docs/notifications/notifications-basic#notification-led-color">LED Color</a></td>
+      <td>✅</td>
+      <td></td>
+    </tr>
+    <tr>
       <td><a href="/docs/notifications/notifications-basic">Message</a></td>
       <td>✅</td>
       <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="/docs/notifications/notifications-basic#persistent-notification">Persistent</a></td>
+      <td>✅</td>
+      <td></td>
     </tr>
     <tr>
       <td><a href="/docs/notifications/notifications-basic#controlling-how-a-notification-is-displayed-when-in-the-foreground">Presentation</a></td>
@@ -197,6 +227,11 @@ Not all features are supported by Android at the moment but eventually most feat
       <td></td>
     </tr>
     <tr>
+      <td><a href="/docs/notifications/notifications-basic#notification-subject">Subject</a></td>
+      <td>✅</td>
+      <td></td>
+    </tr>
+    <tr>
       <td><a href="/docs/notifications/notifications-basic#subtitle">Subtitle</a></td>
       <td></td>
       <td>✅</td>
@@ -207,9 +242,19 @@ Not all features are supported by Android at the moment but eventually most feat
       <td>✅</td>
     </tr>
     <tr>
+      <td><a href="/docs/notifications/notifications-basic#notification-timeout">Timeout</a></td>
+      <td>✅</td>
+      <td></td>
+    </tr>
+    <tr>
       <td><a href="/docs/notifications/notifications-basic">Title</a></td>
       <td>✅</td>
       <td>✅</td>
+    </tr>
+    <tr>
+      <td><a href="/docs/notifications/notifications-basic#notification-vibration-pattern">Vibration Pattern</a></td>
+      <td>✅</td>
+      <td></td>
     </tr>
     <tr>
       <td><a href="/docs/notifications/notification-attachments">Video</a></td>

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -162,11 +162,6 @@ Not all features are supported by Android at the moment but eventually most feat
       <td>✅</td>
     </tr>
     <tr>
-      <td><a href="/docs/notifications/notifications-basic#notification-grouping">Grouping</a></td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
       <td><a href="/docs/notifications/notifications-basic#notification-message-html-formatting">HTML Formatting</a></td>
       <td>✅</td>
       <td></td>
@@ -238,7 +233,7 @@ Not all features are supported by Android at the moment but eventually most feat
     </tr>
     <tr>
       <td><a href="/docs/notifications/notifications-basic#thread-id-grouping-notifications">Threads</a></td>
-      <td></td>
+      <td>✅</td>
       <td>✅</td>
     </tr>
     <tr>

--- a/docs/notifications/attachments.md
+++ b/docs/notifications/attachments.md
@@ -33,7 +33,7 @@ automation:
             hide-thumbnail: false
 ```
 
-Notes:
+Notes ![iOS](/assets/apple.svg):
 *   The thumbnail of the notification will be the media at the `url`.
 *   The notification content is the media at the `url`.
 *   Attachment can be used with custom push notification categories.
@@ -51,7 +51,10 @@ automation:
         message: "Something happened at home!"
         data:
           image: "https://github.com/home-assistant/home-assistant-assets/blob/master/logo-round-192x192.png?raw=true"
-```           
+```
+
+Notes ![android](/assets/android.svg):
+*   If you are setting the [`icon_url`](basic.md#notification-icon) and `image` property then only the image will be displayed on the device.
 
 
 ## Example

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -318,7 +318,7 @@ automation:
 ### Notification Channel Importance
 
 ![android](/assets/android.svg)
-When you are setting the `channel` for your notification you also have the option to set the `importance` for the `channel` per notification. Possible values for this property are `high`, `low`, `max`, `min` and `default`. To learn more about what each value does see the [FCM docs](https://developer.android.com/training/notify-user/channels#importance). This feature is only for devices on Android 8.0+.
+When you are setting the `channel` for your notification you also have the option to set the `importance` for the `channel` per notification. Possible values for this property are `high`, `low`, `max`, `min` and `default`. To learn more about what each value does see the [FCM docs](https://developer.android.com/training/notify-user/channels#importance). For devices before Android 8.0 this property can be used like `priority` with the same options described up above.
 
 ```yaml
   - alias: Notify of Motion
@@ -329,7 +329,7 @@ When you are setting the `channel` for your notification you also have the optio
       data:
         message: Motion Detected
         data:
-          channel: Motion
+          channel: Motion # For devices on Android 8.0+ only
           importance: high
 ```
 

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -272,7 +272,12 @@ automation:
 Notification channels allows users to separate their notifications easily (i.e. alarm vs laundry) so they can customize aspects like what type of sound is made and a lot of other device specific features. Devices running Android 8.0+ are able to create and manage notification channels on the fly using automations. Once a channel is created you can navigate to your notification settings and you will find the newly created channel, from there you can customize the behavior based on what your device allows.
 
 :::info
-If your device is on Android 8.0+ then some of the notification features may not work unless you specify a `channel`. The following properties will become the default for the `channel` the first time they are set: [`vibrationPattern`](#notification-vibration-pattern), [`ledColor`](#notification-led-color) and [`importance`](#notification-channel-importance). Once the options are set you can manage the channel settings in your notification channel settings for the app. These options will be ignored once they are set for the channel, only lowering of the `importance` will work (if the user has not already modified this).
+If your device is on Android 8.0+ the following properties will become the default for the `channel` the first time they are set: [`vibrationPattern`](#notification-vibration-pattern), [`ledColor`](#notification-led-color) and [`importance`](#notification-channel-importance). Once the options are set you can manage the channel settings in your notification channel settings for the app. These options will be ignored once they are set for the channel, only lowering of the `importance` will work (if the user has not already modified this).
+
+Default values for a channel if not provided will be as follows:
+- Importance: Default which means Default notification importance: shows everywhere, makes noise, but does not visually intrude.
+- Vibration Pattern: Vibration disabled
+- LED Color: LED disabled
 
 Devices running Android 5.0-7.1.2 do not have channels and do not need to worry about this note.
 :::
@@ -295,7 +300,7 @@ automation:
           channel: Motion # name of the channel you wish to create or utilize
 ```
 
-If you wish to remove a channel you will need to send `remove_channel` with the `channel` you wish to remove. Depending on when you installed the app you may want to send `remove_channel` to `channel: Default Channel` to clean up the old default channel:
+If you wish to remove a channel you will need to send `remove_channel` with the `channel` you wish to remove. Depending on when you installed the app you may want to send `remove_channel` to `channel: default` to clean up the old default channel:
 
 ```yaml
 automation:
@@ -313,7 +318,7 @@ automation:
 ### Notification Channel Importance
 
 ![android](/assets/android.svg)
-When you are setting the `channel` for your notification you also have the option to set the `importance` for the `channel` per notification. Possible values for this property are `high`, `low`, `max`, `min` and `default`. To learn more about what each value does see the [FCM docs](https://developer.android.com/training/notify-user/channels#importance). The `channel` property is required for this feature to work.
+When you are setting the `channel` for your notification you also have the option to set the `importance` for the `channel` per notification. Possible values for this property are `high`, `low`, `max`, `min` and `default`. To learn more about what each value does see the [FCM docs](https://developer.android.com/training/notify-user/channels#importance). This feature is only for devices on Android 8.0+.
 
 ```yaml
   - alias: Notify of Motion
@@ -450,7 +455,7 @@ You can add some custom HTML tags to the `message` of your notification.
 ### Notification Icon
 
 ![android](/assets/android.svg)
-You can set the icon for a notification by providing the `icon_url`. The URL must be publicly accessible much like the `image` property. It is important to note that if you set the `image` then Android will not show the icon for the notification.
+You can set the icon for a notification by providing the `icon_url`. The URL provided must be either publicly accessible or can be a relative path (i.e. `/local/icon/icon.png`), more details can be found in [attachments](attachments.md). It is important to note that if you set the `image` then Android will not show the icon for the notification, the `image` will be shown in its place. So the `message` will be shown with the `image` and with the image as the icon.
 
 ```yaml
   - alias: Notify of Motion
@@ -461,5 +466,5 @@ You can set the icon for a notification by providing the `icon_url`. The URL mus
       data:
         message: Motion Detected
         data:
-          icon_url: "https://github.com/home-assistant/home-assistant-assets/blob/master/logo-round-192x192.png?raw=true" # Publicly accessible URL
+          icon_url: "https://github.com/home-assistant/home-assistant-assets/blob/master/logo-round-192x192.png?raw=true"
 ```

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -345,7 +345,7 @@ automation:
 ### Persistent Notification
 
 ![android](/assets/android.svg)
-Persistent notifications are notifications that cannot be dimissed. These are useful if you have something important like an alarm being triggered. In order to use this property you must set the `tag` property as well. The `persistent` property only takes boolean (`true/false`) values.
+Persistent notifications are notifications that cannot be dimissed. These are useful if you have something important like an alarm being triggered. In order to use this property you must set the `tag` property as well. The `persistent` property only takes boolean (`true/false`) values, with `false` being the default.
 
 In the example below we will create a notification and then later on we will remove it.
 

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -255,6 +255,12 @@ automation:
 ![android](/assets/android.svg)
 Notification channels allows users to separate their notifications easily (i.e. alarm vs laundry) so they can customize aspects like what type of sound is made and a lot of other device specific features. Devices running Android 8.0+ are able to create and manage notification channels on the fly using automations. Once a channel is created you can navigate to your notification settings and you will find the newly created channel, from there you can customize the behavior based on what your device allows.
 
+:::info
+If your device is on Android 8.0+ then some of the notification features may not work unless you specify a `channel`. The following properties will become the default for the `channel` if not provided: [`vibrationPattern`](#notification-vibration-pattern), [`ledColor`](#notification-led-color) and [`importance`](#notification-channel-importance).
+
+Devices running Android 5.0-7.1.2 do not have channels and do not need to worry about this note.
+:::
+
 In order to create a notification you will need to specify the `channel` you wish to use. By default all notifications use `General` if `channel` is not defined.
 
 In the example below a new channel will be created with the name `Motion`:

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -97,6 +97,22 @@ automation:
             thread-id: "example-notification-group"
 ```
 
+![android](/assets/android.svg)
+For Android we will need to use the `group` property in order to group the notifications together and declutter the notification pull-down.
+
+```yaml
+automation:
+  - alias: Notify of Motion
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
+      data:
+        message: Motion detected
+        data:
+          group: Motion # name of the group you wish to use
+```
+
 ### Replacing notifications
 ![iOS](/assets/apple.svg)
 Existing notifications can be replaced using `apns-collapse-id`. This will continue to send you notifications but replace an existing one with that same `apns-collapse-id`. When sending consecutive messages with the same `apns-collapse-id` to the same device, only the most recent will be shown. This is especially useful for motion and door sensor notifications.
@@ -310,36 +326,6 @@ When you are setting the `channel` for your notification you also have the optio
         data:
           channel: Motion
           importance: high
-```
-
-### Notification Grouping
-
-![android](/assets/android.svg)
-Notification groups allows for notifications to be bundled together with the same `group` that you define in the automation. This allows for the notification pull-down to look less cluttered.
-
-In the examples below we will attach 2 messages to the same group:
-
-```yaml
-automation:
-  - alias: Notify of Motion
-    trigger:
-      ...
-    action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: Motion detected
-        data:
-          group: Motion # name of the group you wish to use
-
-  - alias: Notify of Motion again
-    trigger:
-      ...
-    action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: Motion detected again
-        data:
-          group: Motion # name of the group you wish to use
 ```
 
 ### Persistent Notification

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -255,7 +255,7 @@ automation:
 ![android](/assets/android.svg)
 Notification channels allows users to separate their notifications easily (i.e. alarm vs laundry) so they can customize aspects like what type of sound is made and a lot of other device specific features. Devices running Android 8.0+ are able to create and manage notification channels on the fly using automations. Once a channel is created you can navigate to your notification settings and you will find the newly created channel, from there you can customize the behavior based on what your device allows.
 
-In order to create a notification you will need to specify the `channel` you wish to use. By default all notifications use `Default Channel` if `channel` is not defined.
+In order to create a notification you will need to specify the `channel` you wish to use. By default all notifications use `General` if `channel` is not defined.
 
 In the example below a new channel will be created with the name `Motion`:
 
@@ -273,7 +273,7 @@ automation:
           channel: Motion # name of the channel you wish to create or utilize
 ```
 
-If you wish to remove a channel you will need to send `remove_channel` with the `channel` you wish to remove:
+If you wish to remove a channel you will need to send `remove_channel` with the `channel` you wish to remove. Depending on when you installed the app you may want to send `remove_channel` to `channel: Default Channel` to clean up the old default channel:
 
 ```yaml
 automation:
@@ -286,4 +286,188 @@ automation:
         message: remove_channel
         data:
           channel: Motion # name of the channel you wish to remove
+```
+
+### Notification Channel Importance
+
+![android](/assets/android.svg)
+When you are setting the `channel` for your notification you also have the option to set the `importance` for the `channel` per notification. Possible values for this property are `high`, `low`, `max`, `min` and `default`. To learn more about what each value does see the [FCM docs](https://developer.android.com/training/notify-user/channels#importance). The `channel` property is required for this feature to work.
+
+```yaml
+  - alias: Notify of Motion
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
+      data:
+        message: Motion Detected
+        data:
+          channel: Motion
+          importance: high
+```
+
+### Notification Grouping
+
+![android](/assets/android.svg)
+Notification groups allows for notifications to be bundled together with the same `group` that you define in the automation. This allows for the notification pull-down to look less cluttered.
+
+In the examples below we will attach 2 messages to the same group:
+
+```yaml
+automation:
+  - alias: Notify of Motion
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
+      data:
+        message: Motion detected
+        data:
+          group: Motion # name of the group you wish to use
+
+  - alias: Notify of Motion again
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
+      data:
+        message: Motion detected again
+        data:
+          group: Motion # name of the group you wish to use
+```
+
+### Persistent Notification
+
+![android](/assets/android.svg)
+Persistent notifications are notifications that cannot be dimissed. These are useful if you have something important like an alarm being triggered. In order to use this property you must set the `tag` property as well. The `persistent` property only takes boolean (`true/false`) values.
+
+In the example below we will create a notification and then later on we will remove it.
+
+```yaml
+  - alias: Notify of Motion
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
+      data:
+        message: Motion detected
+        data:
+          persistent: true # Set to true to create a persistent notification
+          tag: persistent # Tag is required for the persistent notification
+```
+
+To remove the persistent notification we send `clear_notification` to the `tag` that we defined.
+
+```yaml
+  - alias: Notify of Motion
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
+      data:
+        message: clear_notification
+        data:
+          tag: persistent # The tag for the persistent notification you wish to clear
+```
+
+### Notification Subject
+
+![android](/assets/android.svg)
+If your notification is going to have a lot of text (more than 6 lines) you can opt to show smaller text by setting the `subject`.
+
+```yaml
+  - alias: Notify of Motion
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
+      data:
+        message: "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+        title: "Long text"
+        data:
+          subject: "Subject for long text"
+```
+
+### Notification LED Color
+
+![android](/assets/android.svg)
+Some Android devices have a multi-color notification LED.  By setting the `ledColor` property you can control what color the LED will flash. Possible values are the same as for property [color](#notification-color) eg '#2DF56D' # or 'red'.
+
+```yaml
+  - alias: Notify of Motion
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
+      data:
+        message: Motion detected
+        data:
+          ledColor: "red" # Set the LED to red
+```
+
+### Notification Vibration Pattern
+
+![android](/assets/android.svg)
+You can set the vibration pattern per notification by setting the `vibrationPattern` property. Possible values are a list of numbers. eg. "100, 1000, 100, 1000, 100" etc.. The pattern specification is "off time, on time, off time, on time, off time" etc.
+
+```yaml
+  - alias: Notify of Motion
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
+      data:
+        message: clear_notification
+        data:
+          vibrationPattern: "100, 1000, 100, 1000, 100" # The pattern you wish to set for vibrations
+```
+
+### Notification Timeout
+
+![android](/assets/android.svg)
+You can set how long a notification will be shown on a users device before being removed/dismissed automatically. You may use the `timeout` property along with the value in seconds to achieve this.
+
+```yaml
+  - alias: Notify of Motion
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
+      data:
+        message: Motion Detected
+        data:
+          timeout: 600 # How many seconds the notification should be received by the device
+```
+
+### Notification Message HTML Formatting
+
+![android](/assets/android.svg)
+You can add some custom HTML tags to the `message` of your notification.
+
+```yaml
+  - alias: Notify of Motion
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
+      data:
+        message: 'This is a <b><span style="color: red">HTML</span></b> <i>text</i><br><br>This is a text after a new line'
+        title: "Cool HTML formatting"
+```
+
+### Notification Icon
+
+![android](/assets/android.svg)
+You can set the icon for a notification by providing the `icon_url`. The URL must be publicly accessible much like the `image` property. It is important to note that if you set the `image` then Android will not show the icon for the notification.
+
+```yaml
+  - alias: Notify of Motion
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
+      data:
+        message: Motion Detected
+        data:
+          icon_url: "https://github.com/home-assistant/home-assistant-assets/blob/master/logo-round-192x192.png?raw=true" # Publicly accessible URL
 ```

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -272,7 +272,7 @@ automation:
 Notification channels allows users to separate their notifications easily (i.e. alarm vs laundry) so they can customize aspects like what type of sound is made and a lot of other device specific features. Devices running Android 8.0+ are able to create and manage notification channels on the fly using automations. Once a channel is created you can navigate to your notification settings and you will find the newly created channel, from there you can customize the behavior based on what your device allows.
 
 :::info
-If your device is on Android 8.0+ then some of the notification features may not work unless you specify a `channel`. The following properties will become the default for the `channel` if not provided: [`vibrationPattern`](#notification-vibration-pattern), [`ledColor`](#notification-led-color) and [`importance`](#notification-channel-importance).
+If your device is on Android 8.0+ then some of the notification features may not work unless you specify a `channel`. The following properties will become the default for the `channel` the first time they are set: [`vibrationPattern`](#notification-vibration-pattern), [`ledColor`](#notification-led-color) and [`importance`](#notification-channel-importance). Once the options are set you can manage the channel settings in your notification channel settings for the app. These options will be ignored once they are set for the channel, only lowering of the `importance` will work (if the user has not already modified this).
 
 Devices running Android 5.0-7.1.2 do not have channels and do not need to worry about this note.
 :::

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -331,7 +331,7 @@ When you are setting the `channel` for your notification you also have the optio
 ### Persistent Notification
 
 ![android](/assets/android.svg)
-Persistent notifications are notifications that cannot be dimissed. These are useful if you have something important like an alarm being triggered. In order to use this property you must set the `tag` property as well. The `persistent` property only takes boolean (`true/false`) values, with `false` being the default.
+Persistent notifications are notifications that cannot be dimissed by swiping away. These are useful if you have something important like an alarm being triggered. In order to use this property you must set the `tag` property as well. The `persistent` property only takes boolean (`true/false`) values, with `false` being the default. The persistent notification will still be dismissed once selected, to avoid this use `sticky: true` so the notification stays.
 
 In the example below we will create a notification and then later on we will remove it.
 


### PR DESCRIPTION
We have several new properties now supported in the Android app since https://github.com/home-assistant/android/pull/612 was merged 🎉

- Icon
- LED Color
- Grouping
- Channel importance
- Vibration Pattern
- Subject
- Timeout
- HTML formatting for `message`
- Persistent notifications

I don't think any of these are supported by iOS at this time but will let the iOS guys comment on that :)

CC: @hasenbolle, I tried to capture everything you had written in your PR and even borrowed parts of it :) Let me know if I captured everything. Since the changes are now live in the beta channel we like to update the docs early to help out those users.