### PR TITLE
Revert "Remove iOS download links"

### DIFF
--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -5,14 +5,7 @@ id: getting-started
 
 ## Installation & System Requirements
 
-The Home Assistant Companion App can be downloaded from the [iOS App Store](/download) or [Play Store](https://play.google.com/store/apps/details?id=io.homeassistant.companion.android). The iOS App requires iOS 10 or greater, this means the oldest devices supported are the iPhone 5, 4<sup>th</sup> generation iPad and the 6<sup>th</sup> generation iPod touch.  The Android app requires Android 5.0 or greater and the device must have Google Play Services in order to function properly.
-
-:::info
-The iOS app has been temporarily removed from the App Store while a bug is fixed. We hope to have it available again soon.
-
-If you've previously downloaded the app, you may be able to download it from your App Store profile following the 
-instructions [here](https://github.com/home-assistant/iOS/issues/598#issuecomment-640234213).
-:::
+The Home Assistant Companion App can be downloaded from the [iOS App Store](https://apps.apple.com/app/home-assistant-companion/id1099568401) or [Play Store](https://play.google.com/store/apps/details?id=io.homeassistant.companion.android). The iOS App requires iOS 10 or greater, this means the oldest devices supported are the iPhone 5, 4<sup>th</sup> generation iPad and the 6<sup>th</sup> generation iPod touch.  The Android app requires Android 5.0 or greater and the device must have Google Play Services in order to function properly.
 
 You need to be running Home Assistant 0.95.0 or newer. The mobile apps requires the following integrations to be enabled in your Home Assistant instance:
 -   `default_config:`

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -41,7 +41,3 @@ html[data-theme='dark'] article img[src$='apple.svg'],
 html[data-theme='dark'] article img[src$='NotificationActionFlow.png'] {
   filter: invert(1.0)
 }
-
-.invert-link, .invert-link:hover {
-  color: var(--ifm-font-color-base);
-}

--- a/src/pages/download.js
+++ b/src/pages/download.js
@@ -17,21 +17,10 @@ function Hello() {
           <h1 className="hero__title">Download the Home Assistant Apps</h1>
           <p className="hero__subtitle">Get the apps now!</p>
           <div className={classnames(styles.buttons, 'download-badges')} >
-          {/* <a href="https://apps.apple.com/us/app/home-assistant/id1099568401?mt=8" style={{display:'inline-block', overflow: 'hidden', background: 'url(https://linkmaker.itunes.apple.com/en-us/badge-lrg.svg?releaseDate=2017-04-15&kind=iossoftware&bubble=apple_music) no-repeat center', width: '155px', height: '40px'}}></a> */}
+          <a href="https://apps.apple.com/us/app/home-assistant/id1099568401?mt=8" style={{display:'inline-block', overflow: 'hidden', background: 'url(https://linkmaker.itunes.apple.com/en-us/badge-lrg.svg?releaseDate=2017-04-15&kind=iossoftware&bubble=apple_music) no-repeat center', width: '155px', height: '40px'}}></a>
           <a href='https://play.google.com/store/apps/details?id=io.homeassistant.companion.android&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'>
             <img alt='Get it on Google Play' width="155" src='https://play.google.com/intl/en_gb/badges/static/images/badges/en_badge_web_generic.png'/>
           </a>
-          </div>
-          <div>
-          <p>
-          <h2>iOS App:</h2>
-          The iOS app has been temporarily removed from the App Store while a bug is fixed. We hope to have it available again soon.
-          <br />
-          <small>
-          If you've previously downloaded the app, you may be able to download it from your App Store profile following the
-          instructions <a className="invert-link" href="https://github.com/home-assistant/iOS/issues/598#issuecomment-640234213">here</a>.
-          </small>
-          </p>
           </div>
         </div>
       </header>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -32,8 +32,8 @@ const features = [
     title: <>Get The Apps</>,
     description: (
       <>
-        {/* <a href="https://apps.apple.com/us/app/home-assistant/id1099568401?mt=8" style={{display:'inline-block', overflow: 'hidden', background: 'url(https://linkmaker.itunes.apple.com/en-us/badge-lrg.svg?releaseDate=2017-04-15&kind=iossoftware&bubble=apple_music) no-repeat center', width: '155px', height: '40px'}}></a>
-        <br /> */}
+        <a href="https://apps.apple.com/us/app/home-assistant/id1099568401?mt=8" style={{display:'inline-block', overflow: 'hidden', background: 'url(https://linkmaker.itunes.apple.com/en-us/badge-lrg.svg?releaseDate=2017-04-15&kind=iossoftware&bubble=apple_music) no-repeat center', width: '155px', height: '40px'}}></a>
+        <br />
         <a href='https://play.google.com/store/apps/details?id=io.homeassistant.companion.android&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'>
         <img alt='Get it on Google Play' width="155" src='https://play.google.com/intl/en_gb/badges/static/images/badges/en_badge_web_generic.png'/>
         </a>


### PR DESCRIPTION
Reverts home-assistant/companion.home-assistant#240 because the app is back on the store now. 

