### PR TITLE
Separate iOS and Android descriptions more clearly

### DIFF
--- a/docs/notifications/critical.md
+++ b/docs/notifications/critical.md
@@ -2,14 +2,11 @@
 title: "Critical notifications"
 id: "critical-notifications"
 ---
+The configuration and behavior of critical notifications differ between iOS and Android.
 
-Critical notifications were introduced in iOS 12 and are designed for sending high-priority notifications that you don't want to miss - for example security system, water leak sensor, and smoke/CO2 alarm alerts.
+![iOS](/assets/apple.svg) Critical notifications were introduced in iOS 12 and are designed for sending high-priority notifications that you don't want to miss - for example security system, water leak sensor, and smoke/CO2 alarm alerts.
 
 iOS gives special priority to this type of notification. Critical alerts always appear at the top of your lock screen above all other notifications, and play a sound even if Do Not Disturb is enabled or the iPhone is muted. Because we never want you to miss a critical notification, they are allowed to bypass the app [notification rate limits](details.md) as well.
-
-For Android these notifications are designed to show up on the phone immediately. By default they do not override Do Not Disturb settings, if you would like to override this you will need to use [notification channels](basic.md#notification-channels). They also do not make the notification sound when the phone is muted.
-
-A simple example of sending a critical notification is:
 
 ![iOS](/assets/apple.svg) iOS example
 
@@ -33,8 +30,13 @@ automations:
               volume: 1.0
 
 ```
+If you have previously read the [sounds documentation](sounds.md) this syntax should be mostly familiar. Note the example expands the `sound` attribute to include the `critical: 1` flag, and `volume: 1.0` to set the volume to 100 %.
 
-![android](/assets/android.svg) Android example for high priority notification
+For **CarPlay** users, it's also worth mentioning that critical notifications are the only ones that can appear on the car's built-in display, making them very useful if you want to know when something critical happens while you're driving.
+
+![android](/assets/android.svg) For Android these notifications are designed to show up on the phone immediately. By default they do not override Do Not Disturb settings, if you would like to override this you will need to use [notification channels](basic.md#notification-channels). They also do not make the notification sound when the phone is muted.
+
+Android example
 
 ```yaml
 automations:
@@ -52,7 +54,3 @@ automations:
           ttl: 0
           priority: high
 ```
-
-If you have previously read the [sounds documentation](sounds.md) this syntax should be mostly familiar. Note the example expands the `sound` attribute to include the `critical: 1` flag, and `volume: 1.0` to set the volume to 100 %.
-
-![iOS](/assets/apple.svg) For **CarPlay** users, it's also worth mentioning that critical notifications are the only ones that can appear on the car's built-in display, making them very useful if you want to know when something critical happens while you're driving.


### PR DESCRIPTION
Reorganization of the page. Previously, for example, description of the sounds: key in iOS followed the Android code example.