### PR TITLE
Fix Google Analytics

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -6,7 +6,6 @@ module.exports = {
   favicon: 'img/favicon.png',
   organizationName: 'home-assistant', // Usually your GitHub org/user name.
   projectName: 'companion.home-assistant', // Usually your repo name.
-  plugins: ['@docusaurus/plugin-google-analytics'],
   themeConfig: {
     navbar: {
       title: 'Companion Apps',


### PR DESCRIPTION
Remove `plugin` line from site config which is not needed and in fact causes build to fail
