### PR TITLE
Add docs index redirect

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -6,5 +6,6 @@
 /core/actions /docs/core/actions
 /docs/integrations/watch/watch /docs/apple-watch/apple-watch
 /next/integrations/apple-watch /docs/apple-watch/apple-watch
-/docs/integrations/watch/watch-actions/ /docs/integrations/watch/actions
-/docs/integrations/watch/complications/ /ocs/integrations/watch/complications
+/docs/integrations/watch/watch-actions/ /docs/apple-watch/actions
+/docs/integrations/watch/complications/ /docs/apple-watch/complications
+/docs /docs/getting_started/getting-started/


### PR DESCRIPTION
In Docusaurus V2 alpha 58 which should drop any moment via dependabot, there is a breaking change that a page will not be built for /docs which we currently have as the getting started guide. This PR just puts in a quick redirect to cover that. Also fixes some errors in the last ones (my bad)
