### PR TITLE
Update iOS accepted colour formats

### DIFF
--- a/docs/integrations/theming.md
+++ b/docs/integrations/theming.md
@@ -11,7 +11,7 @@ id: 'theming'
 
 ![iOS](/assets/android.svg)Colors should be specified in hex format (e.g. `#0099ff`) and defining element colors through variable names is not supported.
 
-![iOS](/assets/apple.svg)As of version 2020.3, the iOS app will accept colors specified in hex, rgb, hsl, rgba, hsla formats or using a valid [HTML color name](https://www.w3schools.com/colors/colors_names.asp); although formats with alpha values are recognized, using alpha values less than 100 % (or 1) will currently lead to a color mismatch. 2020.2 and earlier versions of the app require colors to be specified in hex
+![iOS](/assets/apple.svg)As of version 2020.3, the iOS app will accept colors specified in hex, rgb, hsl, rgba, hsla formats or using a valid [HTML color name](https://www.w3schools.com/colors/colors_names.asp); although formats with alpha values are recognized, using alpha values less than 100 % (or 1) will currently lead to a color mismatch. 2020.2 and earlier versions of the app require colors to be specified in hex.
 
 ## Setting the app theme
 

--- a/docs/integrations/theming.md
+++ b/docs/integrations/theming.md
@@ -11,7 +11,7 @@ id: 'theming'
 
 ![iOS](/assets/android.svg)Colors should be specified in hex format (e.g. `#0099ff`) and defining element colors through variable names is not supported.
 
-![iOS](/assets/apple.svg)As of version 2020.3, the iOS app will accept colors specified as hex, rgb, hsl, rgba, hsla formats or by a valid [HTML color name](https://www.w3schools.com/colors/colors_names.asp), although formats with alpha values are recognized, using alhpa values less than 100 % (or 1) will currently lead to a color mismatch. Earlier versions of the app require colors to be specified in hex
+![iOS](/assets/apple.svg)As of version 2020.3, the iOS app will accept colors specified in hex, rgb, hsl, rgba, hsla formats or using a valid [HTML color name](https://www.w3schools.com/colors/colors_names.asp); although formats with alpha values are recognized, using alpha values less than 100 % (or 1) will currently lead to a color mismatch. 2020.2 and earlier versions of the app require colors to be specified in hex
 
 ## Setting the app theme
 

--- a/docs/integrations/theming.md
+++ b/docs/integrations/theming.md
@@ -9,7 +9,9 @@ id: 'theming'
 - `app-header-background-color` for the status bar background color ![iOS](/assets/apple.svg)
 - `primary-color` for the status bar background color ![android](/assets/android.svg); for the pull-to-refresh control/spinner ![iOS](/assets/apple.svg)
 
-Colors should be specified in hex format (e.g. `#0099ff`) and defining element colors through variable names is not supported.
+![iOS](/assets/android.svg)Colors should be specified in hex format (e.g. `#0099ff`) and defining element colors through variable names is not supported.
+
+![iOS](/assets/apple.svg)As of version 2020.3, the iOS app will accept colors specified as hex, rgb, hsl, rgba, hsla formats or by a valid [HTML color name](https://www.w3schools.com/colors/colors_names.asp), although formats with alpha values are recognized, using alhpa values less than 100 % (or 1) will currently lead to a color mismatch. Earlier versions of the app require colors to be specified in hex
 
 ## Setting the app theme
 


### PR DESCRIPTION
Wee support hex, rgb(a), hsl(a) and colour names now. Although there is an issue with using alphas less than 1