### PR TITLE
Add Launch and Periodic states to Last Update Trigger

### DIFF
--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -89,7 +89,8 @@ If the connection type is not recognized, either `Unknown` or `Unknown Technolog
 | State | Description |
 | --------- | --------- |
 | Manual | A manual update is triggered when the user pulls to refresh. |
-| Initial | Sensors are updated upon initial app launch. |
+| Launch | Sensors are updated upon initial app launch. |
+| Periodic | Updates periodically according to your settings in App Configuration -> Sensors. |
 | Significant Location Change | Triggers when there has been a significant change in the device’s location, such as 500 meters or more. See [location](location.md) for additional details. |
 | Geographic Region Entered | Triggered when entering any user-specified Home Assistant [zone](https://www.home-assistant.io/components/zone/) (also known as geofencing). |
 | Geographic Region Exited | Triggered when exiting any user-specified Home Assistant [zone](https://www.home-assistant.io/components/zone/) (also known as geofencing). |


### PR DESCRIPTION
Added the new "Launch" (replaces Initial) and "Periodic" states for Last Update Trigger sensor (iOS 2020.3 app).