### PR TITLE
Changing Internal/External from UI gated behind Advanced Mode

### DIFF
--- a/docs/troubleshooting/setup.md
+++ b/docs/troubleshooting/setup.md
@@ -7,7 +7,7 @@ Below is a list of common issues and troubleshooting advice to address them. For
 
 ## App crashes on set up
 
-If you are running Home Assistant 0.110 and the app crashes after clicking "continue" during set up, you need to add values for `internal_url` and `external_url`. This can be done through the user interface (Configuration>General). If these fields are disabled it is likely you have have your configuration stored in `configuration.yaml`, in this case add the entries under `homeassistant:` i.e.:
+If you are running Home Assistant 0.110 and the app crashes after clicking "continue" during set up, you need to add values for `internal_url` and `external_url`. This can be done through the user interface (Configuration>General). If you do not see this section, you may need to turn on "Advanced Mode" from your profile page first. If these fields are disabled it is likely you have have your configuration stored in `configuration.yaml`, in this case add the entries under `homeassistant:` i.e.:
 
 ```yaml
 homeassistant:


### PR DESCRIPTION
Editing the internal and external options in the Home Assistant UI under Configuration > General requires the user to have "Advanced Mode" toggle enabled. Otherwise this section will be completely hidden. 

Advanced Mode isn't enabled by default on new installs, so a good idea to point this out.