### PR TITLE
Update iOS beta link

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -3,7 +3,7 @@
 
 # Landing points for links from apps
 /app/ios/patreon https://patreon.com/robbiet480/
-/app/ios/beta https://testflight.apple.com/join/VBsqCiBv
+/app/ios/beta https://testflight.apple.com/join/XCUga7ko
 /app/ios/review https://itunes.apple.com/app/id1099568401?action=write-review&mt=8
 /app/ios/translate https://developers.home-assistant.io/docs/en/internationalization_translation.html
 /app/ios/chat https://discord.gg/C7fXPmt


### PR DESCRIPTION
Dropping the beta build TF so this moves the link in app to point to the release stream
