### PR TITLE
Add info about new widget and sensors for android

### DIFF
--- a/docs/core/android-widgets.md
+++ b/docs/core/android-widgets.md
@@ -7,15 +7,17 @@ The ![android](/assets/android.svg) Android app allows the user to create widget
 
 ## Entity State
 
-This widget will update every 30 minutes or when it is tapped.
+This widget will update every 30 minutes or when it is tapped. This widget will allow the user to select any entity they wish to get the state and an attribute from as well as setting the text size and adding a custom separator between the state and attributes.
 
 1.  Long press on any open space in the home screen
 2.  Scroll down to Home Assistant in the widget list
 3.  Drag the Entity State widget to an open space on the home screen
 4.  Enter the Entity ID you wish to view the state of
 5.  If needed select the attribute checkbox and select the attribute you wish to add to the state
-6.  Supply a name for the widget
-7.  Save the widget
+6.  If needed adjust the widget text size
+7.  If needed add a custom separator to sit between the state and attribute
+8.  Supply a name for the widget
+9.  Save the widget
 
 
 ## Service Call
@@ -29,3 +31,14 @@ This widget will make the service call when it is tapped. The user will see a gr
 5.  Fill in the required service data for the selected service call
 6.  Supply a name and icon for the widget
 7.  Save the widget
+
+
+## Template
+
+This widget will display any text that you wish to show in a widget using [Home Assistants templating feature](https://www.home-assistant.io/docs/configuration/templating/). This is an advanced feature but allows the user to display a wide variety of data. The widget will render the templates live below the text field so you can preview what it would look like.
+
+1.  Long press on any open space in the home screen
+2.  Scroll down to Home Assistant in the widget list
+3.  Drag the Template widget to an open space on the home screen
+4.  Fill in the template data and observe the rendering below
+5.  Save the widget

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -429,8 +429,8 @@ Not all features are supported by Android at the moment but eventually most feat
     </tr>
     <tr>
       <td><a href="/docs/core/sensors#pedometer-sensors">Steps</a></td>
-      <td></td>
-      <td></td>
+      <td>✅</td>
+      <td>✅</td>
       <td>✅</td>
     </tr>
     <tr>

--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -386,6 +386,12 @@ Not all features are supported by Android at the moment but eventually most feat
       <td>✅</td>
     </tr>
     <tr>
+      <td><a href="/docs/core/sensors#last-reboot-sensor">Last Reboot</a></td>
+      <td>✅</td>
+      <td>✅</td>
+      <td></td>
+    </tr>
+    <tr>
       <td><a href="/docs/core/sensors#last-update-trigger-sensor">Last Update Trigger</a></td>
       <td></td>
       <td></td>
@@ -411,14 +417,14 @@ Not all features are supported by Android at the moment but eventually most feat
     </tr>
     <tr>
       <td><a href="/docs/core/sensors#cellular-provider-sensor">Sim 1</a></td>
-      <td></td>
-      <td></td>
+      <td>✅</td>
+      <td>✅</td>
       <td>✅</td>
     </tr>
     <tr>
       <td><a href="/docs/core/sensors#cellular-provider-sensor">Sim 2</a></td>
-      <td></td>
-      <td></td>
+      <td>✅</td>
+      <td>✅</td>
       <td>✅</td>
     </tr>
     <tr>

--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -49,6 +49,7 @@ Each sensor below can be disabled by navigating to the `App Configuration` page 
 | `sensor.light` | None | The current level of illuminance the device detects. |
 | `sensor.phone_state` | None | The only tracked states are `idle`, `ringing` or `offhook`, no other information is accessed. |
 | `sensor.next_alarm` | [See Below](#next-alarm-sensor) | Date of the next scheduled alarm. |
+| `sensor.steps` | None | The number of steps taken from the user since the last device reboot. |
 | `sensor.storage` | [See Below](#storage-sensor) | The amount of total and available internal & external storage on your Android device. |
 | `sensor.wifi_connection` | `bssid`, `ip_address`, `link_speed`, `is_hidden`, `is_wifi_on`, `frequency`, `signal_level` | The state of the sensor will show the name of the connected network or `<not connected>`. |
 
@@ -145,6 +146,7 @@ Geocoding is handled directly by iOS's [MapKit](https://developer.apple.com/docu
 | `sensor.floors_ascended` | The approximate number of floors ascended by walking. |
 | `sensor.floors_descended` | The approximate number of floors descended by walking. |
 
+![android](/assets/android.svg) Android users will only have a `sensor.steps` entity which will represent the total number of steps taken since the last device reboot.
 
 ## Cellular Provider Sensor
 ![iOS](/assets/apple.svg) The cellular provider sensor displays information about the user’s cellular service provider, such as its unique identifier and whether it allows VoIP calls on its network. `sensor.sim_1` corresponds to the physical SIM card installed and `sensor.sim_2` corresponds to the eSIM (this is only shown if the eSIM is enabled).

--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -46,9 +46,12 @@ Each sensor below can be disabled by navigating to the `App Configuration` page 
 | `sensor.battery_state` | `is_charging`, `charger_type` | The state of the sensor reflects the current state of the battery ([See Below](#battery-sensors)). The `is_charging` attribute will be either `true` or `false`. The `charger_type` attribute will show either `ac`, `usb`, `wireless` or `unknown`. |
 | `sensor.bluetooth_connection` | [See Below](#bluetooth-sensor) | The state of the sensor will reflect the total number of connected bluetooth devices. |
 | `sensor.geocoded_location` | [See Below](#geocoded-location-sensor) | Calculated address based on GPS data. |
+| `sensor.last_reboot` | [See Below](#last-reboot-sensor) | The timestamp of the device's last reboot. |
 | `sensor.light` | None | The current level of illuminance the device detects. |
 | `sensor.phone_state` | None | The only tracked states are `idle`, `ringing` or `offhook`, no other information is accessed. |
 | `sensor.next_alarm` | [See Below](#next-alarm-sensor) | Date of the next scheduled alarm. |
+| `sensor.sim_1` | [See Below](#cellular-provider-sensor) | Name of your cellular provider. |
+| `sensor.sim_2` | [See Below](#cellular-provider-sensor) | Name of your cellular provider. |
 | `sensor.steps` | None | The number of steps taken from the user since the last device reboot. |
 | `sensor.storage` | [See Below](#storage-sensor) | The amount of total and available internal & external storage on your Android device. |
 | `sensor.wifi_connection` | `bssid`, `ip_address`, `link_speed`, `is_hidden`, `is_wifi_on`, `frequency`, `signal_level` | The state of the sensor will show the name of the connected network or `<not connected>`. |
@@ -149,17 +152,19 @@ Geocoding is handled directly by iOS's [MapKit](https://developer.apple.com/docu
 ![android](/assets/android.svg) Android users will only have a `sensor.steps` entity which will represent the total number of steps taken since the last device reboot.
 
 ## Cellular Provider Sensor
-![iOS](/assets/apple.svg) The cellular provider sensor displays information about the user’s cellular service provider, such as its unique identifier and whether it allows VoIP calls on its network. `sensor.sim_1` corresponds to the physical SIM card installed and `sensor.sim_2` corresponds to the eSIM (this is only shown if the eSIM is enabled).
+The cellular provider sensor displays information about the user’s cellular service provider, such as its unique identifier and whether it allows VoIP calls on its network. `sensor.sim_1` corresponds to the physical SIM card installed and `sensor.sim_2` corresponds to the eSIM (this is only shown if the eSIM is enabled).
 
 | Attribute | Description |
 | --------- | --------- |
 | `Carrier Name` | The name of the user’s home cellular service provider. |
-| `Current Radio Technology` |  |
+| `Current Radio Technology` | ![iOS](/assets/apple.svg) only. |
 | `ISO Country Code` | The ISO country code for the user’s cellular service provider. |
 | `Mobile Country Code` | The mobile country code (MCC) for the user’s cellular service provider. |
 | `Mobile Network Code` | The mobile network code for the user’s cellular service provider. |
 | `Carrier ID` |  |
-| `Allows VoIP` | Indicates if the carrier allows making VoIP calls on its network. |
+| `Allows VoIP` | Indicates if the carrier allows making VoIP calls on its network. ![iOS](/assets/apple.svg) |
+| `Is Opportunistic` | An opportunistic subscription connects to a network that is limited in functionality and / or coverage. ![android](/assets/android.svg) |
+| `Data Roaming` | Is data roaming enabled for the device. ![android](/assets/android.svg) |
 
 
 ## Storage Sensor
@@ -207,3 +212,12 @@ Geocoding is handled directly by iOS's [MapKit](https://developer.apple.com/docu
 
 ## Light Sensor
 ![android](/assets/android.svg) This sensor will reflect the current level of illuminance the device detects. Devices that do not have a light sensor will show `unavailable`. The sensor updates during the normal sensor update interval or with the other sensor updates.
+
+
+## Last Reboot Sensor
+![android](/assets/android.svg) This sensors state will be the date and time of the last reboot from the device in UTC format. The sensor will update during the normal sensor update interval. The state will be `unavailable` if the timestamp cannot be determined.
+
+| Attribute | Description |
+| --------- | --------- |
+| `Local Time` | The date and time of the last reboot in local time. |
+| `Time in Milliseconds` | The time date and time of the last reboot in milliseconds. |


### PR DESCRIPTION
A new [template widget](https://github.com/home-assistant/android/pull/790) and [step sensor](https://github.com/home-assistant/android/pull/792) were added so adding some info about it.

We also just added sim 1 and sim 2: https://github.com/home-assistant/android/pull/786

As well as a last reboot sensor: https://github.com/home-assistant/android/pull/794