### PR TITLE
Hack dark mode css inverts

### DIFF
--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -32,7 +32,7 @@ When sending a notification:
 3.  Action tapped.
 4.  Identifier of action sent back to HA as the `actionName` property of the event `ios.notification_action_fired`, along with other metadata such as the device and category name.
 
-![How the iOS device and Home Assistant work together to enable actionable notifications.](/assets/NotificationActionFlow.png)
+<img alt="How the iOS device and Home Assistant work together to enable actionable notifications." class="invertDark" src="/assets/NotificationActionFlow.png" />
 
 ## Definitions
 -   **Category** - A category represents a type of notification that the app might receive. Think of it as a unique group of actions.

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -44,9 +44,9 @@ article img[src$='apple.svg'] {
   max-height: 2ex;
 }
 
-html[data-theme='dark'] article img[src$='android.svg'],
-html[data-theme='dark'] article img[src$='apple.svg'],
-html[data-theme='dark'] article img[src$='NotificationActionFlow.png'] {
+html[data-theme='dark'] article img[alt='android'],
+html[data-theme='dark'] article img[alt='iOS'],
+html[data-theme='dark'] .invertDark {
   filter: invert(1.0)
 }
 


### PR DESCRIPTION
A recent Docusaurus change means that image file names are now replaced with apparent junk, presumably during optimization. I.e., `andorid.svg` is going to `data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz48IURPQ1RZUEUgc3ZnIFBVQkxJQyAiLS8vVzNDLy9EVEQgU1ZHIDEuMS8vRU4iICJodHRwOi8vd3d3LnczLm9yZy9HcmFwaGljcy9TVkcvMS4xL0RURC9zdmcxMS5kdGQiPjxzdmcgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgdmVyc2lvbj0iMS4xIiB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCI+PHBhdGggZD0iTTE2LjYxIDE1LjE1QzE2LjE1IDE1LjE1IDE1Ljc3IDE0Ljc4IDE1Ljc3IDE0LjMyUzE2LjE1IDEzLjUgMTYuNjEgMTMuNUgxNi42MUMxNy4wNyAxMy41IDE3LjQ1IDEzLjg2IDE3LjQ1IDE0LjMyQzE3LjQ1IDE0Ljc4IDE3LjA3IDE1LjE1IDE2LjYxIDE1LjE1TTcuNDEgMTUuMTVDNi45NSAxNS4xNSA2LjU3IDE0Ljc4IDYuNTcgMTQuMzJDNi41NyAxMy44NiA2Ljk1IDEzLjUgNy40MSAxMy41SDcuNDFDNy44NyAxMy41IDguMjQgMTMuODYgOC4yNCAxNC4zMkM4LjI0IDE0Ljc4IDcuODcgMTUuMTUgNy40MSAxNS4xNU0xNi45MSAxMC4xNEwxOC41OCA3LjI2QzE4LjY3IDcuMDkgMTguNjEgNi44OCAxOC40NSA2Ljc5QzE4LjI4IDYuNjkgMTguMDcgNi43NSAxOCA2LjkyTDE2LjI5IDkuODNDMTQuOTUgOS4yMiAxMy41IDguOSAxMiA4LjkxQzEwLjQ3IDguOTEgOSA5LjI0IDcuNzMgOS44Mkw2LjA0IDYuOTFDNS45NSA2Ljc0IDUuNzQgNi42OCA1LjU3IDYuNzhDNS40IDYuODcgNS4zNSA3LjA4IDUuNDQgNy4yNUw3LjEgMTAuMTNDNC4yNSAxMS42OSAyLjI5IDE0LjU4IDIgMThIMjJDMjEuNzIgMTQuNTkgMTkuNzcgMTEuNyAxNi45MSAxMC4xNEgxNi45MVoiIC8+PC9zdmc+`.

This is all good and well except my old hacky way of inverting things like the OS logos when switching to and from dark mode was relying on CSS selectors matching those filenames.

This fixes the problem for the action flow by including as HTML and giving it a class. We cant do this sadly for the OS icons as in the wisdom of MDX HTML snippets seem to get put ion their own `<p>...</p>` for no good reason (I believe this is fixed in MDX2). So for the OS icons I'm hacking the hack by matching to the alt text until we get MDX2.