### PR TITLE
Update android start fresh steps

### DIFF
--- a/docs/troubleshooting/setup.md
+++ b/docs/troubleshooting/setup.md
@@ -82,10 +82,9 @@ At times you may need to start fresh with the Android app as a new feature may n
 
 1.  Check that Home Assistant Core and the Android app are up to date.
 2.  Clear Storage or App data in Android app.
-3.  In Home Assistant navigate to Configuration > Integration. Remove the mobile app entry for the device in question.
+3.  In Home Assistant navigate to Configuration > Integration. Remove the mobile app entry for the device in question. If you see more than 1 remove them all.
 4.  Restart Home Assistant.
 5.  Log back into Android app. If you have more than 1 device make sure to rename the device under App Configuration.
-6.  Restart Home Assistant once more to register the `notify.mobile_app` service call.
 
 ## Location is not updating in Android app
 If you find that location updates are not coming in here are a few things to check.


### PR DESCRIPTION
The restart after renaming the device is no longer needed.  If a user has more than 1 entry (due to an old bug) they should remove all entries.