### PR TITLE
Add info about android migration failure event

### DIFF
--- a/docs/integrations/app-events.md
+++ b/docs/integrations/app-events.md
@@ -5,8 +5,10 @@ id: 'app-events'
 
 ## Overview
 
+
+To help with running automations, such as clearing app icon badges, or other tasks you may wish to trigger based on app usage the Home Assistant Companion Apps will fire different events onto the Home Assistant [event bus](https://www.home-assistant.io/docs/configuration/events/) during certain situations.
+
 ![iOS](/assets/iOS.svg)<br />
-To help with running automations, such as clearing app icon badges, or other tasks you may wish to trigger based on app usage, the Home Assistant Companion App fires three different events onto the Home Assistant [event bus](https://www.home-assistant.io/docs/configuration/events/) when you open or close the app.
 
 | Event | Cause |
 | ----- | ----- |
@@ -15,5 +17,11 @@ To help with running automations, such as clearing app icon badges, or other tas
 | `ios.became_active` | The app is opened whether or not it was already in the background. |
 | `ios.zone_entered` | A zone was entered. If this zone is smaller than 100m, this will include a `multi_region_zone_id` key. |
 | `ios.zone_exited` | A zone was exited. If this zone is smaller than 100m, this will include a `multi_region_zone_id` key. |
+
+![Android](/assets/android.svg) Android<br />
+
+| Event | Cause |
+| ----- | ----- |
+| `mobile_app.migration_failed` | The app database was corrupted and has been reset during the migration to allow the app to open. Sensors will need to be re-enabled and widgets will need to be recreated. A notification will also be posted on the device informing the user of the issue. |
 
 You can use the Events page within Home Assistant's developer tools to show all information contained with the event for a particular event by subscribing to the event you are interested in and carrying out the appropriate action with on your device.


### PR DESCRIPTION
We found a couple odd situations in Sentry where the app database would fail to migrate crashing the app and not allowing the user to open the app.

We are now catching those exceptions which occur during the migration and informing the user of the crash by posting a notification and also including an event so the admin can create their own automations.

What we saw was that in some cases the sensors table would exist but no rows existed, this data is not expected to be empty. 

We also saw a case where a blob was stored in the database, we don't store blobs so it must've been corrupted by some other means or just bad API data.