### PR TITLE
Add info about android power menu integration

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -26,6 +26,12 @@ Not all features are supported by Android at the moment but eventually most feat
       <td>✅</td>
     </tr>
     <tr>
+      <td><a href="/docs/integrations/android-power-menu">Android Power Menu</a></td>
+      <td>✅</td>
+      <td>✅</td>
+      <td></td>
+    </tr>
+    <tr>
       <td><a href="/docs/integrations/android-widgets">Android Widgets</a></td>
       <td>✅</td>
       <td>✅</td>

--- a/docs/integrations/android-power-menu.md
+++ b/docs/integrations/android-power-menu.md
@@ -1,0 +1,15 @@
+---
+title: "Android Power Menu"
+id: 'android-power-menu'
+---
+
+<span class="beta">BETA</span><br /><br />
+
+The ![Android](/assets/android.svg) Android app will automatically integrate with the [Android 11 power menu controls](https://developer.android.com/guide/topics/ui/device-control) feature on devices that support it. All that is required is that you are able to login to the app and use it remotely. Once you are logged into the app you can then long hold the power button on your device and you will be able to "Add Controls" from the Home Assistant app. All domains listed below will be available to get added to the power menu. Tapping on a tile will either turn it on or off. Certain domains will also allow for the user increase or decrease the range by sliding their finger back and forth on the tile.
+
+Currently support is limited to the following domains:
+
+*  `input_boolean` On/Off
+*  `input_number` Number control slider
+*  `light` On/Off, Brightness control slider
+*  `switch` On/Off

--- a/sidebars.js
+++ b/sidebars.js
@@ -34,6 +34,7 @@ module.exports = {
       'notifications/notification-sounds'],
     'Integrations': [
       'integrations/integrations',
+      'integrations/android-power-menu',
       'integrations/android-widgets',
       'integrations/app-events',
       'integrations/haptics',


### PR DESCRIPTION
Docs for: https://github.com/home-assistant/android/pull/1027

Also makes use of the newly added beta tag :) will submit another PR to mark the current beta features properly later on.