### PR TITLE
Remove beta flags for next android release

### DIFF
--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -350,7 +350,7 @@ This sensor uses the [ipify API](https://www.ipify.org/) in order to determine t
 
 ## Sleep as Android Sensors
 
-![Android](/assets/android.svg)<br />
+![Android](/assets/android.svg)
 
 For users who have the [Sleep as Android](https://play.google.com/store/apps/details?id=com.urbandroid.sleep&hl=en_US) app installed you will be able to enable a few sensors that represent states from their [Intent API](https://docs.sleep.urbandroid.org/devs/intent_api.html#events-emitted-by-sleep). The states will all update as soon as the intent is received.
 

--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -238,7 +238,7 @@ Using the [History Stats Integration](https://www.home-assistant.io/integrations
 
 
 ## Last Notification Sensor
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+![Android](/assets/android.svg)<br />
 This sensor will reflect the last notification posted on the device. This sensor requires a special permission that the app will take the user to so they can grant access to notifications. This sensors state will default to the text of the notification or if not available the posting package name. This sensor offers a setting to enable an Allow List to let the user select which packages they wish to get notification data from, notifications sent by Home Assistant are always ignored. We recommend that users make use of this setting as by default all notifications including invisible ones get sent and might cause unintentional battery drain if the setting is left untouched. This can be very useful to integrate any app that sends a notification but does not offer direct integration (ex: food delivery apps or 2FA SMS codes). There are several attributes a user can expect to see, although not all attributes will contain data. This sensor makes use of the [NotificationListenerService API](https://developer.android.com/reference/android/service/notification/NotificationListenerService#onNotificationRemoved(android.service.notification.StatusBarNotification)).  More details on each attribute can be found in the [Notification Extras](https://developer.android.com/reference/android/app/Notification).
 
 | Attribute | Description |
@@ -270,7 +270,7 @@ This sensors state will be the date and time of the last reboot from the device 
 
 
 ## Last Update Trigger Sensor
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span>
+![Android](/assets/android.svg)
 
 For android this sensors state will reflect the [intent](https://developer.android.com/reference/android/content/Intent) of the most recent update sent.
 
@@ -350,7 +350,7 @@ This sensor uses the [ipify API](https://www.ipify.org/) in order to determine t
 
 ## Sleep as Android Sensors
 
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span> <br />
+![Android](/assets/android.svg)<br />
 
 For users who have the [Sleep as Android](https://play.google.com/store/apps/details?id=com.urbandroid.sleep&hl=en_US) app installed you will be able to enable a few sensors that represent states from their [Intent API](https://docs.sleep.urbandroid.org/devs/intent_api.html#events-emitted-by-sleep). The states will all update as soon as the intent is received.
 

--- a/docs/integrations/android-power-menu.md
+++ b/docs/integrations/android-power-menu.md
@@ -3,7 +3,6 @@ title: "Android Power Menu"
 id: 'android-power-menu'
 ---
 
-<span class="beta">BETA</span><br /><br />
 
 The ![Android](/assets/android.svg) Android app will automatically integrate with the [Android 11 power menu controls](https://developer.android.com/guide/topics/ui/device-control) feature on devices that support it. All that is required is that you are able to login to the app and use it remotely. Once you are logged into the app you can then long hold the power button on your device and you will be able to "Add Controls" from the Home Assistant app. All domains listed below will be available to get added to the power menu. Tapping on a tile will either turn it on or off. Certain domains will also allow for the user increase or decrease the range by sliding their finger back and forth on the tile.
 

--- a/docs/integrations/android-widgets.md
+++ b/docs/integrations/android-widgets.md
@@ -22,8 +22,6 @@ This widget will update every 30 minutes or when it is tapped. This widget will 
 
 ## Media Player
 
-<span class="beta">BETA</span><br /><br />
-
 This widget will let the user control any media player on their home screen. There are a couple of options available to hide or show the seek and skip buttons.
 
 1.  Long press on any open space in the home screen

--- a/docs/integrations/app-events.md
+++ b/docs/integrations/app-events.md
@@ -18,7 +18,7 @@ To help with running automations, such as clearing app icon badges, or other tas
 | `ios.zone_entered` | A zone was entered. If this zone is smaller than 100m, this will include a `multi_region_zone_id` key. |
 | `ios.zone_exited` | A zone was exited. If this zone is smaller than 100m, this will include a `multi_region_zone_id` key. |
 
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+![Android](/assets/android.svg)<br />
 
 | Event | Cause |
 | ----- | ----- |

--- a/docs/integrations/app-events.md
+++ b/docs/integrations/app-events.md
@@ -18,7 +18,8 @@ To help with running automations, such as clearing app icon badges, or other tas
 | `ios.zone_entered` | A zone was entered. If this zone is smaller than 100m, this will include a `multi_region_zone_id` key. |
 | `ios.zone_exited` | A zone was exited. If this zone is smaller than 100m, this will include a `multi_region_zone_id` key. |
 
-![Android](/assets/android.svg)<br />
+![Android](/assets/android.svg)
+
 
 | Event | Cause |
 | ----- | ----- |

--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -115,7 +115,7 @@ automation:
 For Android you create the action directly in the automation action. The below example will give you 3 actions in your notification. The first action will send back an event with the action `alarm` and the second action will open the URL or load a lovelace view/dashboard. If you plan to use a lovelace view the format would be `/lovelace/test` where `test` is replaced by your defined [`path`](https://www.home-assistant.io/lovelace/views/#path) in the defined view. If you plan to use a lovelace dashboard the format would be `/lovelace-dashboard/view` where `/lovelace-dashboard/` is replaced by your defined [`dashboard`](https://www.home-assistant.io/lovelace/dashboards-and-views/#dashboards) URL and `view` is replaced by the defined [`path`](https://www.home-assistant.io/lovelace/views/#path) within that dashboard. 
 
 
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+![Android](/assets/android.svg)<br />
 If you want to open an application you need to set the action to `URI`.  To pick the application to open prefix `app://` to the the package name.  If the device does not have the application installed then the Home Assistant application will open to the default page.
 
 ```yaml
@@ -136,7 +136,7 @@ automation:
               uri: "https://google.com" # URL to open when action is selected, can also be a lovelace view/dashboard
             - action: "URI" # Must be set to URI if you plan to open an application
               title: "Open Twitter"
-              uri: "app://com.twitter.android" # Name of package for application you would like to open (Android Beta only)
+              uri: "app://com.twitter.android" # Name of package for application you would like to open
 ```
 
 When an action is selected an event named `ios.notification_action_fired` for iOS and `mobile_app_notification_action` for Android will be emitted on the Home Assistant event bus. Below is an example payload.

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -519,7 +519,7 @@ You can set the icon for a notification by providing the `icon_url`. The URL pro
 
 ### Text To Speech Notifications
 
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+![Android](/assets/android.svg)<br />
 Instead of posting a notification on the device you can instead get your device to speak the notification. This notification works different than the others. You will set `message: TTS` and the actual text to speak would be in the `title`. Current support is limited to the current Text To Speech locale set on the device. If there is an error processing the message you will see a toast message appear on the device. Check to make sure that the Text To Speech engine is up to date in case you run into any issues.
 
 ```yaml

--- a/docs/notifications/cleared.md
+++ b/docs/notifications/cleared.md
@@ -3,7 +3,7 @@ title: "Notification Cleared"
 id: "notification-cleared"
 ---
 
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+![Android](/assets/android.svg)
 
 When a notification is cleared Android will notify the Companion app of the event. Along with ensuring that the groups are canceled, the app will send a `mobile_app_notification_cleared` event to your Home Assistant instance. This event will contain all of the notification data that was sent to the device. This event will fire with each and every notification that gets cleared.
 

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -65,7 +65,7 @@ automation:
 
 ## Do Not Disturb
 
-![Android](/assets/android.svg) &nbsp;Android 6+ only<br />
+![Android](/assets/android.svg) &nbsp;Android 6+ only
 
 On Android you can send `message: command_dnd` that you can use to control the state of Do Not Disturb on the device. This command requires a specific permission that the app is unable to prompt or auto-accept. Instead by sending the command for the first time the app will launch an activity allowing the user to enable Home Assistant access to the devices Notification Policy. This is required in order for the app to gain control of this setting.
 

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -26,7 +26,7 @@ The Companion apps offer a lot of different notification options. In place of po
 
 ## Broadcast Intent
 
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span> <br />
+![Android](/assets/android.svg) <br />
 
 Using notification commands you are now able to send a broadcast intent to another app in order to control that app based on the intent. Not all apps support intents and if they do they may document it for users to control. There are no `extras` provided at this time, it is only for sending an intent to another app. You must set `message: command_broadcast_intent` and the `title` must contain the intent action while `channel` must contain the package the intent is for. The package name and action are provided by the app you wish to send the intent to. If an invalid format is sent you may either see a notification or a toast message.
 
@@ -65,7 +65,7 @@ automation:
 
 ## Do Not Disturb
 
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span> &nbsp;Android 6+ only<br />
+![Android](/assets/android.svg) &nbsp;Android 6+ only<br />
 
 On Android you can send `message: command_dnd` that you can use to control the state of Do Not Disturb on the device. This command requires a specific permission that the app is unable to prompt or auto-accept. Instead by sending the command for the first time the app will launch an activity allowing the user to enable Home Assistant access to the devices Notification Policy. This is required in order for the app to gain control of this setting.
 
@@ -123,7 +123,7 @@ While it is possible to create an automation in Home Assistant to call this serv
 
 ## Ringer Mode
 
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+![Android](/assets/android.svg)<br />
 
 On Android you can control the devices ringer mode by sending `message: command_ringer_mode` with an appropriate `title` as outlined in the table below. Certain devices will need to grant a special permission that will appear upon the first command received if the permission was not already granted. This is the same permission as [Do Not Disturb](#do-not-disturb) up above. If the device has Do Not Disturb enabled then setting to `normal` or `vibrate` will turn it off. If the device does not have Do Not Disturb enabled then `silent` will turn it on.<br />
 

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -123,7 +123,7 @@ While it is possible to create an automation in Home Assistant to call this serv
 
 ## Ringer Mode
 
-![Android](/assets/android.svg)<br />
+![Android](/assets/android.svg)
 
 On Android you can control the devices ringer mode by sending `message: command_ringer_mode` with an appropriate `title` as outlined in the table below. Certain devices will need to grant a special permission that will appear upon the first command received if the permission was not already granted. This is the same permission as [Do Not Disturb](#do-not-disturb) up above. If the device has Do Not Disturb enabled then setting to `normal` or `vibrate` will turn it off. If the device does not have Do Not Disturb enabled then `silent` will turn it on.<br />
 

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -26,7 +26,7 @@ The Companion apps offer a lot of different notification options. In place of po
 
 ## Broadcast Intent
 
-![Android](/assets/android.svg) <br />
+![Android](/assets/android.svg)
 
 Using notification commands you are now able to send a broadcast intent to another app in order to control that app based on the intent. Not all apps support intents and if they do they may document it for users to control. There are no `extras` provided at this time, it is only for sending an intent to another app. You must set `message: command_broadcast_intent` and the `title` must contain the intent action while `channel` must contain the package the intent is for. The package name and action are provided by the app you wish to send the intent to. If an invalid format is sent you may either see a notification or a toast message.
 

--- a/docs/notifications/critical.md
+++ b/docs/notifications/critical.md
@@ -57,7 +57,7 @@ automations:
           priority: high
 ```
 
-![Android](/assets/android.svg) &nbsp; <span class="beta">BETA</span><br />
+![Android](/assets/android.svg)<br />
 You can also force the notification to play from the alarm stream so it will make the device ring even if on vibrate/silent ringer mode. Users on Android 7 and below can still use the `channel` example below as we are just using it to override the default notification behavior for sound. In order to make a notification show up immediately and make a sound regardless of ringer mode follow one of the examples below.
 
 Using this method to can send a normal notification:


### PR DESCRIPTION
To be merged alongside: https://github.com/home-assistant/home-assistant.io/pull/15531 after we decide upon a date for the android release