### PR TITLE
Remove sleep as android sensors

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -512,12 +512,6 @@ Not all features are supported by Android at the moment but eventually most feat
       <td>✅</td>
     </tr>
     <tr>
-      <td><a href="/docs/core/sensors#sleep-as-android-sensors">Sleep as Android</a></td>
-      <td>✅</td>
-      <td>✅</td>
-      <td></td>
-    </tr>
-    <tr>
       <td><a href="/docs/core/sensors">SSID</a></td>
       <td></td>
       <td></td>

--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -64,7 +64,6 @@ All sensors update during a periodic 15-minute interval and they will also updat
 | `sensor.next_alarm` | [See Below](#next-alarm-sensor) | Date of the next scheduled alarm. |
 | `sensor.sim_1` | [See Below](#cellular-provider-sensor) | Name of your cellular provider. |
 | `sensor.sim_2` | [See Below](#cellular-provider-sensor) | Name of your cellular provider. |
-| [Sleep as Android Sensors](#sleep-as-android-sensors) | None | Sensors that represent the Sleep as Android Intent API. |
 | `sensor.steps` | None | The number of steps taken from the user since the last device reboot. Requires activity recognition permissions on supported devies. |
 | [Storage Sensors](#storage-sensor) | [See Below](#storage-sensor) | The amount of total and available internal & external storage on your Android device. |
 | [Traffic Stats Sensor](#traffic-stats-sensor) | None | Amount of data transmitted and received from mobile and total device usage since last reboot. |
@@ -346,19 +345,6 @@ This sensor will show the current proximity reading from the device. This sensor
 ## Public IP Sensor
 ![Android](/assets/android.svg)<br />
 This sensor uses the [ipify API](https://www.ipify.org/) in order to determine the devices public IP address. This sensor will update during the normal sensor update interval.
-
-
-## Sleep as Android Sensors
-
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span> <br />
-
-For users who have the [Sleep as Android](https://play.google.com/store/apps/details?id=com.urbandroid.sleep&hl=en_US) app installed you will be able to enable a few sensors that represent states from their [Intent API](https://docs.sleep.urbandroid.org/devs/intent_api.html#events-emitted-by-sleep). The states will all update as soon as the intent is received.
-
-| Sensor | Description |
-| ------ | ----------- |
-| `lullaby` | Whether or not a lullaby is actively playing. |
-| `sleep_events` | One off events such as snoozing the alarm, dismissing the alarm etc... See the link up above for all possible events. |
-| `sleep_tracking` | Whether or not sleep tracking is currently active. |
 
 
 ## Storage Sensor


### PR DESCRIPTION
We had a last minute to decision to pull these sensors as we think of a better approach on integrating 3rd party apps.