### PR TITLE
Remove beta labels for android release 3.0.2

### DIFF
--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -198,7 +198,7 @@ For Android several different types of connection sensors are available and they
 ![Android](/assets/android.svg) The `bssid` sensor offers settings to let you rename the current mac address to help avoid the need for templates and secret usage in automations and the front end. This is generally useful if you have multiple access points and want an easy way to differentiate between them. These settings are turned off by default. These sensors require either [Background Location](https://developer.android.com/reference/android/Manifest.permission#ACCESS_BACKGROUND_LOCATION) or [Fine Location](https://developer.android.com/reference/android/Manifest.permission#ACCESS_FINE_LOCATION) permissions, depending on what version of Android you run.
 
 ## Current Time Zone Sensor
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+![Android](/assets/android.svg)
 This sensor will represent the current time zone the device is in. There are also a few attributes to help describe this time zone. Data is provided by the [TimeZone API](https://developer.android.com/reference/java/util/TimeZone.html).
 
 | Attribute | Description |
@@ -209,7 +209,7 @@ This sensor will represent the current time zone the device is in. There are als
 | `uses_daylight_time` | If the current time zone observes daylight time. |
 
 ## Current Version Sensor
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+![Android](/assets/android.svg)
 This sensor will represent the current installed version of the Android app.
 
 ## Do Not Disturb Sensor

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -565,7 +565,7 @@ If you find that your alarm stream volume is too low you can use `channel: alarm
 
 ### Chronometer Notifications
 
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+![Android](/assets/android.svg)<br />
 You can create notifications with a count up/down timer (chronometer) by passing the `chronometer` and `when` options. This feature requires at least Android 7.0.
 
 Do note that the notification will not disappear when the timer reaches 0. Instead, it will continue decrementing into negative values.

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -150,7 +150,7 @@ automation:
 
 ## Volume Level
 
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+![Android](/assets/android.svg)
 
 On Android you can control the devices volume level by sending `message: command_volume_level` with an appropriate `title` that must be a number. If `title` is larger than the maximum level then the maximum level will be used or if `title` is less than `0` then we will default to `0`, anything else will result in the notification posting to the device. `channel` is also required as outlined in the table below. Certain devices will need to grant a special permission that will appear upon the first command received if the permission was not already granted. This is the same permission as [Do Not Disturb](#do-not-disturb) up above. Changing the volume level will have a direct impact on Do Not Disturb and Ringer Modes, behavior will vary from device to device.<br />
 


### PR DESCRIPTION
We just made a new release so need to remove some beta labels: https://github.com/home-assistant/android/releases/tag/3.0.2