### PR TITLE
Add a troubleshooting step for android crash logs

### DIFF
--- a/docs/troubleshooting/setup.md
+++ b/docs/troubleshooting/setup.md
@@ -130,3 +130,26 @@ If you have more than 1 device of the same model and you did not rename your dev
 2.  Select Manage Widgets.
 3.  Find any widget that no longer exists on your home screen.
 4.  Delete the widget to remove it from the list and to stop the toast messages.
+
+## Android Crash Logs
+![Android](/assets/android.svg) The Android app makes use of Google's ADB [Logcat](https://developer.android.com/studio/command-line/logcat) feature to log errors. From time to time you may wish to inspect the logs or a developer may ask for crash logs in order to fix your issue. There are multiple ways to get the logs off the device. Unfortunately you will need to use a computer with a USB cable as you either need to setup Android Studio or you need to grant special ADB permissions.
+
+The easiest way to get the logs would be to use [Logcat Reader](https://play.google.com/store/apps/details?id=com.dp.logcatapp) from the Google Play Store, you can also use [Android Studio](https://developer.android.com/studio). Either method requires you to grant special permissions, you will need to follow the instructions provided by the method to ensure you get the proper level of verbose logging. Some devices may require a USB driver in order to be recognized, every device is different and you may need to refer to the manufacturer if it doesn't work out of the box.
+
+Once you have your method setup you will want to search by `homeassistant` in order to find the logs.
+
+Here is an example of a crash log:
+
+```
+2020-12-09 14:44:24.224 18523-18571/io.homeassistant.companion.android E/SensorReceiver: Issue registering sensor: charger_type
+    io.homeassistant.companion.android.common.data.integration.IntegrationException
+        at io.homeassistant.companion.android.common.data.integration.impl.IntegrationRepositoryImpl.registerSensor(IntegrationRepositoryImpl.kt:449)
+        at io.homeassistant.companion.android.sensors.SensorReceiver.updateSensors(SensorReceiver.kt:142)
+        at io.homeassistant.companion.android.sensors.SensorReceiver$onReceive$1.invokeSuspend(SensorReceiver.kt:106)
+        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
+        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
+        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
+        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
+        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
+        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
+```


### PR DESCRIPTION
Finally found a good app thats more friendly than directly recommending Android Studio.  Its still requires some setup to get the logs off the device but I figured we should have something mentioned to help users out when they want to help investigate.  Also provided a brief example of a crash log so they know what to look for.