### PR TITLE
Clarify map template example

### DIFF
--- a/docs/notifications/dynamic-content.md
+++ b/docs/notifications/dynamic-content.md
@@ -22,7 +22,13 @@ data:
 ```
 Be aware, that to send a map you must send a push `category` which has to be called `map`, `map1`, `map2`, `map3` or `map4`  otherwise you won't get the map delivered.
 
-You may also use a device_tracker for the latitude and longitude coordinates like so: `"{{states.device_tracker.<your_device_id_here>.attributes.latitude}}"` but make sure to use `data_template` in that case.
+You may also use a `device_tracker` for the latitude and longitude coordinates like so:
+
+```yaml
+    action_data:
+      latitude: "{{states.device_tracker.<your_device_id_here>.attributes.latitude}}"
+      longitude: "{{states.device_tracker.<your_device_id_here>.attributes.longitude}}"
+```
 
 ### Showing a second pin
 

--- a/docs/notifications/dynamic-content.md
+++ b/docs/notifications/dynamic-content.md
@@ -22,6 +22,8 @@ data:
 ```
 Be aware, that to send a map you must send a push `category` which has to be called `map`, `map1`, `map2`, `map3` or `map4`  otherwise you won't get the map delivered.
 
+### Providing coordinates using templates <span class="beta">BETA</span><br />
+
 You may also use a `device_tracker` for the latitude and longitude coordinates like so:
 
 ```yaml

--- a/docs/notifications/dynamic-content.md
+++ b/docs/notifications/dynamic-content.md
@@ -28,8 +28,8 @@ You may also use a `device_tracker` for the latitude and longitude coordinates l
 
 ```yaml
     action_data:
-      latitude: "{{states.device_tracker.<your_device_id_here>.attributes.latitude}}"
-      longitude: "{{states.device_tracker.<your_device_id_here>.attributes.longitude}}"
+      latitude: "{{ state_attr("device_tracker.<your_device_id_here>", "latitude") }}"
+      longitude: "{{ state_attr("device_tracker.<your_device_id_here>", "longitude") }}"
 ```
 
 ### Showing a second pin


### PR DESCRIPTION
We no longer need to use the `data_template` key so ditch that confusion (child key called data too). Currently due to typing of templates, requires a work around in app which is (will be) in next  beta

Fixes #414