### PR TITLE
Fix macOS labels not inverting in dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -61,6 +61,7 @@ article img[alt='Android']{
 
 html[data-theme='dark'] article img[alt='Android'],
 html[data-theme='dark'] article img[alt='iOS'],
+html[data-theme='dark'] article img[alt='macOS'],
 html[data-theme='dark'] article img[alt='Apple'],
 html[data-theme='dark'] .invertDark {
   filter: invert(1.0)


### PR DESCRIPTION
The macOS images weren't inverting when we went from light mode to dark mode. This fixes that.