### PR TITLE
Match macOS icon size to iOS size

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -35,7 +35,7 @@ table.core-table td:nth-child(n+2){
   text-align: center;
 }
 
-article img[alt='iOS'] {
+article img[alt='iOS'], article img[alt='macOS'] {
   display: inline;
   margin-left: auto;
   margin-right: auto;


### PR DESCRIPTION
Missed this before apparently

### Before:
![deploy-preview-435--home-assistant-companion-docs netlify app_docs_core_sensors_](https://user-images.githubusercontent.com/12411302/105636016-00e6e200-5e5e-11eb-88d3-1cb96a569eb2.png)


### After:
![localhost_3000_docs_core_sensors (1)](https://user-images.githubusercontent.com/12411302/105635996-deed5f80-5e5d-11eb-952d-210137d49065.png)

