### PR TITLE
Rearrange some stuff, add beta tags, formatting

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -410,7 +410,7 @@ Not all features are supported by Android at the moment but eventually most feat
       <td>✅</td>
     </tr>
     <tr>
-      <td><a href="/docs/core/sensors#bluetooth-sensor">Bluetooth Sensor</a></td>
+      <td><a href="/docs/core/sensors#bluetooth-sensors">Bluetooth Sensors</a></td>
       <td>✅</td>
       <td>✅</td>
       <td></td>

--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -230,11 +230,14 @@ This Bluetooth Connection state will be the total number of connected bluetooth 
 
 There will also be a binary sensor for the `bluetooth_state` that will represent whether or not bluetooth is turned on for the device. This sensor will update anytime the state of bluetooth changes.
 
-A BLE Transmitter sensor allows your device to transmit a BLE iBeacon.  This is useful in conjunction with projects like [roomassistant](https://www.room-assistant.io/) and [esp32-mqtt-room ](https://jptrsn.github.io/ESP32-mqtt-room/) to allow room level tracking.  The current trasnmitting ID (UUID-Major-Minor) is reported as an attribute that can be copied for use with these systems.
+![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+A BLE Transmitter sensor allows your device to transmit a BLE iBeacon.  This is useful in conjunction with projects like [roomassistant](https://www.room-assistant.io/) and [esp32-mqtt-room ](https://jptrsn.github.io/ESP32-mqtt-room/) to allow room level tracking.  The current transmitting ID (UUID-Major-Minor) is reported as an attribute that can be copied for use with these systems.
 
-Warning, this sensor can impact battery life, particularly if used wih Transmit Power set to High. The iBeacon is transmitted every second (low latency to save battery, but sufficient for room presence).
+:::caution
+This sensor can impact battery life, particularly if used wih Transmit Power set to High. The iBeacon is transmitted every second (low latency to save battery, but sufficient for room presence).
+:::
 
-Settings are available to change the UUID, Major and Minor masks.  These can be used to change the overall identifier, as well as to allow groups, e.g. family phone devices can have particular Major value which can be whitelisted in apps like roomassistant.  These settings are validated: UUID should be the [standard format](https://en.wikipedia.org/wiki/Universally_unique_identifier), Major and Minor need to be within 0 and 65535. There are also settings to change the Transmit power (between Ultra Low, Low, Medium and High) as well as as toggle to allow this sensor to be turned on when the Enable all sensors toggle is activated.  This is set to false, to prevent this sensor draining battery unnecessarily
+Settings are available to change the UUID, Major and Minor masks. These can be used to change the overall identifier, as well as to allow groups, e.g. family phone devices can have particular Major value which can be whitelisted in apps like roomassistant. These settings are validated: UUID should be the [standard format](https://en.wikipedia.org/wiki/Universally_unique_identifier), Major and Minor need to be within 0 and 65535. There are also settings to change the Transmit power (between Ultra Low, Low, Medium and High) as well as as toggle to allow this sensor to be turned on when the Enable all sensors toggle is activated. This is set to false, to prevent this sensor draining battery unnecessarily
 
 
 ## Cellular Provider Sensor

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -19,7 +19,7 @@ The Companion apps offer a lot of different notification options. In place of po
 | `clear_notification` | Removes a notification from the status bar, [more details](basic.md#replacing-notifications). |
 | `command_activity` | Launch an activity with a specified URI to any app, [more details](#activity) and use cases below. |
 | `command_bluetooth` | Turn bluetooth on or off. |
-| `command_ble_transmitter` | Turn BLE beacon transmitter on or off. |
+| `command_ble_transmitter` | Turn BLE beacon transmitter on or off. <span class="beta">BETA</span><br /> |
 | `command_broadcast_intent` | Send a broadcast intent to another app, [see below](#broadcast-intent) for how it works and whats required. |
 | `command_dnd` | Control Do Not Disturb mode on the device, [see below](#do-not-disturb) for how it works and whats required. |
 | `command_high_accuracy_mode` | Control the high accuracy mode of the background location sensor, [see below](#high-accuracy-mode) for how it works and whats required. |
@@ -76,6 +76,26 @@ automation:
         data:
           channel: "com.google.android.apps.maps"
           tag: "android.intent.action.VIEW"
+```
+
+## BLE Beacon Transmitter
+
+![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+
+Users can turn the iBeacon transmitter on or off using `message: command_ble_transmitter` with the `title` being either `turn_off` or `turn_on`. If `title` is blank, not set or not one of the above expected values then the notification will post as normal.
+
+Example:
+
+```yaml
+automation:
+  - alias: Turn off BLE transmitter
+    trigger:
+      ...
+    action:
+      service: notify.mobile_app_<your_device_id_here>
+      data:
+        message: "command_ble_transmitter"
+        title: "turn_off"
 ```
 
 
@@ -307,24 +327,4 @@ automation:
       data:
         message: "command_webview"
         title: "/lovelace/settings"
-```
-
-## BLE Beacon Transmitter
-
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
-
-Users can turn the iBeacon transmitter on or off using `message: command_ble_transmitter` with the `title` being either `turn_off` or `turn_on`. If `title` is blank, not set or not one of the above expected values then the notification will post as normal.
-
-Example:
-
-```yaml
-automation:
-  - alias: Notify Mobile app
-    trigger:
-      ...
-    action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "command_ble_transmitter"
-        title: "turn_off"
 ```


### PR DESCRIPTION
We had rearranged the commands to be alphabetical, also missed a beta tag in the table itself.

Changed the warning to an actual caution label for the sensor

Small formatting changes (too many spaces after the period)

Fixed the comparison table for the new header