### PR TITLE
Remove beta tags for android april 2021 release

### DIFF
--- a/docs/core/location.md
+++ b/docs/core/location.md
@@ -151,7 +151,7 @@ If you use both constraints (Bluetooth, Zone), then only one constraint must app
 
 You can also enable the high accuracy mode only when connected to specific Bluetooth devices with the option `High accuracy mode only when connected to BT devices`. Be sure that the option `High accuracy mode (May drain battery fast)` is also enabled.
 
-#### Zones constraint &nbsp;<span class="beta">BETA</span>
+#### Zones constraint
 
 Additionally, you can enable the high accuracy mode when entering a specific zone with the option `High accuracy mode only when entering zone`. If you want to enable the high accuracy mode before entering the zone, you can use the option `High accuracy mode trigger range for zone (meters)`. With this option enabled, a expanded zone (only app internal) around the original zone will be created. If you reach that expanded zone the high accuracy mode will be enabled and then disabled when you reach the original zone. Please have a look at the zone examples.
 

--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -216,7 +216,7 @@ The battery sensors listed below describe the state of the battery for a few dif
 | `battery_health` | The health of the battery |
 | `battery_level` | The percentage of battery remaining |
 | `battery_state` | The state of charging on the device |
-| `battery_temperature` | The current battery temperature <span class="beta">BETA</span> |
+| `battery_temperature` | The current battery temperature |
 | `charger_type` | The type of charger being used on the device |
 | `is_charging` | Whether or not the device is actively charging |
 
@@ -241,8 +241,6 @@ This sensor can impact battery life, particularly if used wih Transmit Power set
 :::
 
 Settings are available to change the UUID, Major and Minor masks. These can be used to change the overall identifier, as well as to allow groups, e.g. family phone devices can have particular Major value which can be whitelisted in apps like roomassistant. These settings are validated: UUID should be the [standard format](https://en.wikipedia.org/wiki/Universally_unique_identifier), Major and Minor need to be within 0 and 65535. There are also settings to change the Transmit power (between Ultra Low, Low, Medium and High) as well as as toggle to allow this sensor to be turned on when the Enable all sensors toggle is activated. This is set to false, to prevent this sensor draining battery unnecessarily.
-
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
 
 A Transmit setting toggle will start or stop the BLE transmissions - this setting is also toggled via the notification command that can turn the services on and off. 
 

--- a/docs/integrations/android-shortcuts.md
+++ b/docs/integrations/android-shortcuts.md
@@ -3,7 +3,7 @@ title: "Android Shortcuts"
 id: 'android-shortcuts'
 ---
 
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+![Android](/assets/android.svg)
 
 The Android app offers support for both dynamic and pinned [shortcuts](https://developer.android.com/guide/topics/ui/shortcuts). Shortcuts allow users to navigate to a specific lovelace page or entity directly from the home screen without needing to first launch the app. Supported devices will see a Manage Shortcuts section under App Configuration. From there users must supply the Label which appears in the launcher (Google recommends 10 characters). The description must also be provided as some launchers may prefer to display it (Google recommends 25 characters).
 

--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -148,8 +148,6 @@ If you plan to use a lovelace view instead of a URL for action `URI` then the fo
 
 If you want to open an application you need to set the action to `URI`. The format will be `app://<package>` where `<package>` is replaced by the package you wish to open (ex: `app://com.twitter.android`). If the device does not have the application installed then the Home Assistant application will open to the default page.
 
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
-
 With action set to `URI` you can also trigger the More Info panel for any entity. The format will be `entityId:<entity_ID>` where `<entity_id>` is replaced with the entity ID you wish to view. Ex: `entityId:sun.sun`
 
 ```yaml

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -278,7 +278,7 @@ automation:
 ![Android](/assets/android.svg)<br />
 When a notification is selected the user can either be navigated to a another application, a specific lovelace view/dashboard, or you can have a webpage open to any URL. If you plan to use a lovelace view the format would be `/lovelace/test` where `test` is replaced by your defined [`path`](https://www.home-assistant.io/lovelace/views/#path) in the defined view. If you plan to use a lovelace dashboard the format would be `/lovelace-dashboard/view` where `/lovelace-dashboard/` is replaced by your defined [`dashboard`](https://www.home-assistant.io/lovelace/dashboards-and-views/#dashboards) URL and `view` is replaced by the defined [`path`](https://www.home-assistant.io/lovelace/views/#path) within that dashboard.
 
-If you would like to have another application open then format is `app://<package name>` where `<package name>` is replaced with the actual package you wish to open. The default behavior is to just open the Home Assistant app and load the default dashboard.
+If you would like to have another application open, then the format is `app://<package name>` where `<package name>` is replaced with the actual package you wish to open. The default behavior is to just open the Home Assistant app and load the default dashboard.
 
 You can also trigger the More Info panel for any entity by using the following format `entityId:<entity_ID>` where `<entity_id>` is replaced with the entity ID you wish to view. Ex: `entityId:sun.sun`
 

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -276,9 +276,9 @@ automation:
 ### Notification Click Action
 
 ![Android](/assets/android.svg)<br />
-When a notification is selected the user can either be navigated to a another application, a specific lovelace view/dashboard, or you can have a webpage open to any URL. If you plan to use a lovelace view the format would be `/lovelace/test` where `test` is replaced by your defined [`path`](https://www.home-assistant.io/lovelace/views/#path) in the defined view. If you plan to use a lovelace dashboard the format would be `/lovelace-dashboard/view` where `/lovelace-dashboard/` is replaced by your defined [`dashboard`](https://www.home-assistant.io/lovelace/dashboards-and-views/#dashboards) URL and `view` is replaced by the defined [`path`](https://www.home-assistant.io/lovelace/views/#path) within that dashboard. If you would like to have another application open then format is `app://<package name>` where `<package name>` is replaced with the actual package you wish to open. The default behavior is to just open the Home Assistant app and load the default dashboard.
+When a notification is selected the user can either be navigated to a another application, a specific lovelace view/dashboard, or you can have a webpage open to any URL. If you plan to use a lovelace view the format would be `/lovelace/test` where `test` is replaced by your defined [`path`](https://www.home-assistant.io/lovelace/views/#path) in the defined view. If you plan to use a lovelace dashboard the format would be `/lovelace-dashboard/view` where `/lovelace-dashboard/` is replaced by your defined [`dashboard`](https://www.home-assistant.io/lovelace/dashboards-and-views/#dashboards) URL and `view` is replaced by the defined [`path`](https://www.home-assistant.io/lovelace/views/#path) within that dashboard.
 
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+If you would like to have another application open then format is `app://<package name>` where `<package name>` is replaced with the actual package you wish to open. The default behavior is to just open the Home Assistant app and load the default dashboard.
 
 You can also trigger the More Info panel for any entity by using the following format `entityId:<entity_ID>` where `<entity_id>` is replaced with the entity ID you wish to view. Ex: `entityId:sun.sun`
 

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -283,7 +283,7 @@ automation:
 
 ## Screen On
 
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+![Android](/assets/android.svg)
 
 On Android you can turn on the screen using a notification by simply sending `message: command_screen_on`. This will not remove or disable any lock screens you have setup on the device. The reason behind this is the risk associated with the app being unable to set the device policy back (app crash) or if the device requires the policy to be setup again after being removed. All of which is out of the app's control. You may want to adjust the screen timeout setting on your device to control when the screen will turn back off.
 

--- a/docs/troubleshooting/setup.md
+++ b/docs/troubleshooting/setup.md
@@ -162,28 +162,4 @@ If you want to ensure that the sensors are updated when your device starts charg
 4.  Delete the widget to remove it from the list and to stop the toast messages.
 
 ## Android Crash Logs
-![Android](/assets/android.svg) The Android app makes use of Google's ADB [Logcat](https://developer.android.com/studio/command-line/logcat) feature to log errors. From time to time you may wish to inspect the logs or a developer may ask for crash logs in order to fix your issue. There are multiple ways to get the logs off the device. Unfortunately you will need to use a computer with a USB cable as you either need to setup Android Studio or you need to grant special ADB permissions.
-
-The easiest way to get the logs would be to use [Logcat Reader](https://play.google.com/store/apps/details?id=com.dp.logcatapp) from the Google Play Store, you can also use [Android Studio](https://developer.android.com/studio). Either method requires you to grant special permissions, you will need to follow the instructions provided by the method to ensure you get the proper level of verbose logging. Some devices may require a USB driver in order to be recognized, every device is different and you may need to refer to the manufacturer if it doesn't work out of the box.
-
-Once you have your method setup you will want to search by `homeassistant` in order to find the logs.
-
-Here is an example of a crash log:
-
-```
-2020-12-09 14:44:24.224 18523-18571/io.homeassistant.companion.android E/SensorReceiver: Issue registering sensor: charger_type
-    io.homeassistant.companion.android.common.data.integration.IntegrationException
-        at io.homeassistant.companion.android.common.data.integration.impl.IntegrationRepositoryImpl.registerSensor(IntegrationRepositoryImpl.kt:449)
-        at io.homeassistant.companion.android.sensors.SensorReceiver.updateSensors(SensorReceiver.kt:142)
-        at io.homeassistant.companion.android.sensors.SensorReceiver$onReceive$1.invokeSuspend(SensorReceiver.kt:106)
-        at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
-        at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:56)
-        at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:571)
-        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:738)
-        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:678)
-        at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:665)
-```
-
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
-
-There is a new option under App Configuration > Show and Share Logs. This feature makes it a lot of easier to refresh, share and view the logs. The logs can then be used when you want to create an [issue](https://github.com/home-assistant/android/issues/new?assignees=&labels=bug&template=Bug_report.md&title=) or when a developer asks for them to troubleshoot an issue. It is important to note that the device logs may or may not contain sensitive information like your Home Assistant URL so make sure to remove sensitive information before sharing.
+![Android](/assets/android.svg) The Android app makes use of Google's ADB [Logcat](https://developer.android.com/studio/command-line/logcat) feature to log errors. From time to time you may wish to inspect the logs or a developer may ask for crash logs in order to fix your issue. There is an option under App Configuration > Show and Share Logs. This feature makes it a lot of easier to refresh, share and view the logs. The logs can then be used when you want to create an [issue](https://github.com/home-assistant/android/issues/new?assignees=&labels=bug&template=Bug_report.md&title=) or when a developer asks for them to troubleshoot an issue. It is important to note that the device logs may or may not contain sensitive information like your Home Assistant URL so make sure to remove sensitive information before sharing.


### PR DESCRIPTION
We are getting ready to cut an android release soon so removing the beta flags.

Biggest change is that there is now an in-app log viewer thus eliminating the need for the complex steps in log retrieval.

Will need to merge alongside the blog post and when we cut the release later tonight.