### PR TITLE
Update YAML to match style guide

### DIFF
--- a/docs/core/actions.md
+++ b/docs/core/actions.md
@@ -88,8 +88,8 @@ automation:
         event_data:
           actionName: 'Bed Time'
     action:
-      service: light.turn_off
-      entity_id: group.all_lights
+      - service: light.turn_off
+        entity_id: group.all_lights
 ```
 Note that attributes located in the `data` and `context` are accessed through `event_data` and `event_context` respectively within the automation.
 

--- a/docs/core/location.md
+++ b/docs/core/location.md
@@ -32,12 +32,12 @@ The following is a basic example to switch a light on when you enter your _home_
 automation:
   - alias: 'Turn door light on when getting home'
     trigger:
-      platform: state
-      entity_id: device_tracker.<device_ID>
-      to: 'home'
+      - platform: state
+        entity_id: device_tracker.<device_ID>
+        to: 'home'
     condition:
-      condition: sun
-      after: sunset
+      - condition: sun
+        after: sunset
     action:
       - service: light.turn_on
         data:

--- a/docs/core/location.md
+++ b/docs/core/location.md
@@ -34,7 +34,7 @@ automation:
     trigger:
       - platform: state
         entity_id: device_tracker.<device_ID>
-        to: 'home'
+        to: "home"
     condition:
       - condition: sun
         after: sunset

--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -99,16 +99,16 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: "Check this out!"
-        message: "Something happened at home!"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          push:
-            category: "alarm" # Needs to match the top level identifier you used in the ios configuration
-          action_data: # Anything passed in action_data will get echoed back to Home Assistant.
-            entity_id: light.test
-            my_custom_data: foo_bar
+          title: "Check this out!"
+          message: "Something happened at home!"
+          data:
+            push:
+              category: "alarm" # Needs to match the top level identifier you used in the ios configuration
+            action_data: # Anything passed in action_data will get echoed back to Home Assistant.
+              entity_id: light.test
+              my_custom_data: foo_bar
 ```
 
 If you want to navigate to a Lovelace page or launch an app for a notification, you can use the `url` key.
@@ -116,25 +116,25 @@ If you want to navigate to a Lovelace page or launch an app for a notification, 
 To navigate to a dashboard when tapping a notification:
 ```yaml
 action:
-  service: notify.mobile_app_<your_device_id_here>
-  data:
-    message: "Something happened at home!"
+  - service: notify.mobile_app_<your_device_id_here>
     data:
-      url: /lovelace/cameras
+      message: "Something happened at home!"
+      data:
+        url: /lovelace/cameras
 ```
 
 To navigate to a specific dashboard when tapping a notification action:
 ```yaml
 action:
-  service: notify.mobile_app_<your_device_id_here>
-  data:
-    message: "Something happened at home!"
+  - service: notify.mobile_app_<your_device_id_here>
     data:
-      push:
-        category: "ALARM"
-      url: 
-        _: "/lovelace/cameras" # if the notification itself is tapped
-        SOUND_ALARM: "/lovelace/alarm" # if the 'SOUND_ALARM' action is tapped
+      message: "Something happened at home!"
+      data:
+        push:
+          category: "ALARM"
+        url:
+          _: "/lovelace/cameras" # if the notification itself is tapped
+          SOUND_ALARM: "/lovelace/alarm" # if the 'SOUND_ALARM' action is tapped
 ```
 
 You can also use application-launching URLs. For example, launch an external website using `https://example.com` or make a phone call using `tel:2125551212`.
@@ -156,19 +156,19 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "Something happened at home!"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          actions:
-            - action: "alarm" # The key you are sending for the event
-              title: "Title" # The button title
-            - action: "URI" # Must be set to URI if you plan to use a URI
-              title: "Open Url"
-              uri: "https://google.com" # URL to open when action is selected, can also be a lovelace view/dashboard
-            - action: "URI" # Must be set to URI if you plan to open an application
-              title: "Open Twitter"
-              uri: "app://com.twitter.android" # Name of package for application you would like to open
+          message: "Something happened at home!"
+          data:
+            actions:
+              - action: "alarm" # The key you are sending for the event
+                title: "Title" # The button title
+              - action: "URI" # Must be set to URI if you plan to use a URI
+                title: "Open Url"
+                uri: "https://google.com" # URL to open when action is selected, can also be a lovelace view/dashboard
+              - action: "URI" # Must be set to URI if you plan to open an application
+                title: "Open Twitter"
+                uri: "app://com.twitter.android" # Name of package for application you would like to open
 ```
 
 ![Android](/assets/android.svg)
@@ -180,13 +180,13 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "Something happened at home!"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          actions:
-            - action: "REPLY" # This must be set to REPLY in order for the reply feature to be present
-              title: "Title" # The button title
+          message: "Something happened at home!"
+          data:
+            actions:
+              - action: "REPLY" # This must be set to REPLY in order for the reply feature to be present
+                title: "Title" # The button title
 ```
 
 When an action is selected an event named `ios.notification_action_fired` for iOS and `mobile_app_notification_action` for Android will be emitted on the Home Assistant event bus. Below is an example payload.
@@ -238,12 +238,12 @@ Here's an example automation for the given payload:
 
 ```yaml
 automation:
-  - alias: Sound the alarm
+  - alias: Sound the alarm iOS
     trigger:
-      platform: event
-      event_type: ios.notification_action_fired
-      event_data:
-        actionName: SOUND_ALARM
+      - platform: event
+        event_type: ios.notification_action_fired
+        event_data:
+          actionName: SOUND_ALARM
     action:
       ...
 ```
@@ -252,12 +252,12 @@ automation:
 
 ```yaml
 automation:
-  - alias: Sound the alarm
+  - alias: Sound the alarm android
     trigger:
-      platform: event
-      event_type: mobile_app_notification_action
-      event_data:
-        action: alarm
+      - platform: event
+        event_type: mobile_app_notification_action
+        event_data:
+          action: alarm
     action:
       ...
 ```

--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -238,12 +238,12 @@ Here's an example automation for the given payload:
 
 ```yaml
 automation:
-  - alias: Sound the alarm iOS
+  - alias: "Sound the alarm iOS"
     trigger:
       - platform: event
         event_type: ios.notification_action_fired
         event_data:
-          actionName: SOUND_ALARM
+          actionName: "SOUND_ALARM"
     action:
       ...
 ```
@@ -252,12 +252,12 @@ automation:
 
 ```yaml
 automation:
-  - alias: Sound the alarm android
+  - alias: "Sound the alarm Android"
     trigger:
       - platform: event
         event_type: mobile_app_notification_action
         event_data:
-          action: alarm
+          action: "alarm"
     action:
       ...
 ```

--- a/docs/notifications/attachments.md
+++ b/docs/notifications/attachments.md
@@ -33,7 +33,7 @@ automation:
           data:
             attachment:
               url: "https://github.com/home-assistant/assets/blob/master/logo/logo.png?raw=true"
-              content-type: png
+              content-type: "png"
               hide-thumbnail: false
 ```
 

--- a/docs/notifications/attachments.md
+++ b/docs/notifications/attachments.md
@@ -23,18 +23,18 @@ To expand a notification on 3D Touch devices simply force touch any notification
 
 ```yaml
 automation:
-  - alias: Notify Mobile app
+  - alias: Notify Mobile app attachment
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "Something happened at home!"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          attachment:
-            url: "https://github.com/home-assistant/assets/blob/master/logo/logo.png?raw=true"
-            content-type: png
-            hide-thumbnail: false
+          message: "Something happened at home!"
+          data:
+            attachment:
+              url: "https://github.com/home-assistant/assets/blob/master/logo/logo.png?raw=true"
+              content-type: png
+              hide-thumbnail: false
 ```
 
 ![iOS](/assets/iOS.svg)Notes:
@@ -46,15 +46,15 @@ automation:
 
 ```yaml
 automation:
-  - alias: Notify Mobile app
+  - alias: Notify Mobile app image
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "Something happened at home!"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          image: "https://github.com/home-assistant/assets/blob/master/logo/logo.png?raw=true"
+          message: "Something happened at home!"
+          data:
+            image: "https://github.com/home-assistant/assets/blob/master/logo/logo.png?raw=true"
 ```
 
 ![Android](/assets/android.svg) &nbsp; Notes:

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -11,9 +11,9 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: 'Notification text'
+      - service: notify.mobile_app_<your_device_id_here>
+        data:
+          message: 'Notification text'
 ```
 
 The mobile_app platform provides many enhancements to the simple notification generated above. The image below, for example, shows an [iOS actionable notification](actionable.md) allowing you to trigger different automations from each button.
@@ -28,16 +28,16 @@ If you include a URL in your notification, tapping on the notification will open
 
 ```yaml
 automation:
-  - alias: 'Send Notification'
+  - alias: 'Send Notification with link'
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: "Motion Detected in Backyard"
-        message: "Someone might be in the backyard."
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          url: /lovelace/cameras
+          title: "Motion Detected in Backyard"
+          message: "Someone might be in the backyard."
+          data:
+            url: /lovelace/cameras
 ```
 
 URL's can alternatively be included in the `message:` portion of your notification.
@@ -57,12 +57,12 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "Ding-dong"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          push:
-            sound: none
+          message: "Ding-dong"
+          data:
+            push:
+              sound: none
 ```
 
 ### Badge
@@ -71,17 +71,17 @@ You can set the app icon badge in the payload. The below example will make the a
 
 ```yaml
 automation:
-  - alias: Notify Mobile app
+  - alias: Notify Mobile app update badge
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: "Smart Home Alerts"
-        message: "Something happened at home!"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          push:
-            badge: 5
+          title: "Smart Home Alerts"
+          message: "Something happened at home!"
+          data:
+            push:
+              badge: 5
 ```
 
 By setting the message to `delete_alert` you can silently update the app badge icon in the background without sending a notification to your phone.
@@ -92,16 +92,16 @@ A subtitle is supported in addition to the title:
 
 ```yaml
 automation:
-  - alias: Notify Mobile app
+  - alias: Notify Mobile app subtitle
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: "Smart Home Alerts"
-        message: "Something happened at home!"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          subtitle: "Subtitle goes here"
+          title: "Smart Home Alerts"
+          message: "Something happened at home!"
+          data:
+            subtitle: "Subtitle goes here"
 ```
 
 ### Thread-id (grouping notifications)
@@ -110,17 +110,17 @@ Grouping of notifications is supported on iOS 12 and above. All notifications wi
 
 ```yaml
 automation:
-  - alias: Notify Mobile app
+  - alias: Notify Mobile app grouping
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: "Smart Home Alerts"
-        message: "Something happened at home!"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          push:
-            thread-id: "example-notification-group"
+          title: "Smart Home Alerts"
+          message: "Something happened at home!"
+          data:
+            push:
+              thread-id: "example-notification-group"
 ```
 
 ![Android](/assets/android.svg)<br />
@@ -132,11 +132,11 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: Motion detected
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          group: Motion # name of the group you wish to use
+          message: Motion detected
+          data:
+            group: Motion # name of the group you wish to use
 ```
 
 ### Replacing notifications
@@ -145,17 +145,17 @@ Existing notifications can be replaced using `apns-collapse-id`. This will conti
 
 ```yaml
 automation:
-  - alias: Notify of Motion
+  - alias: Notify of Motion iOS replacement
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: "Motion Detected in Backyard"
-        message: "Someone might be in the backyard."
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          apns_headers:
-            apns-collapse-id: 'backyard-motion-detected'
+          title: "Motion Detected in Backyard"
+          message: "Someone might be in the backyard."
+          data:
+            apns_headers:
+              apns-collapse-id: 'backyard-motion-detected'
 ```
 
 ![Android](/assets/android.svg)<br />
@@ -163,16 +163,16 @@ For Android users you can easily replace the notification using the `tag` servic
 
 ```yaml
 automation:
-  - alias: Notify of Motion
+  - alias: Notify of Motion android replacement
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: "Motion Detected in Backyard"
-        message: "Someone might be in the backyard."
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          tag: tag
+          title: "Motion Detected in Backyard"
+          message: "Someone might be in the backyard."
+          data:
+            tag: tag
 ```
 
 ![Android](/assets/android.svg)<br />
@@ -180,15 +180,15 @@ You can also remove a notification by sending `clear_notification` to the same `
 
 ```yaml
 automation:
-  - alias: Notify of Motion
+  - alias: Notify of Motion clear notification
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: clear_notification
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          tag: tag
+          message: clear_notification
+          data:
+            tag: tag
 ```
 
 ### Sending notifications to multiple devices
@@ -207,13 +207,13 @@ notify:
 Now, you can send notifications to everyone in the group using.  If you plan to group Android and iOS devices only `message` and `title` will work:
 ```yaml
   automation:
-    - alias: Notify Mobile app
+    - alias: Notify Mobile app group
       trigger:
         ...
       action:
-        service: notify.ALL_DEVICES
-        data:
-          message: "Something happened at home!"
+        - service: notify.ALL_DEVICES
+          data:
+            message: "Something happened at home!"
 ```
 
 ### Controlling how a notification is displayed when in the foreground
@@ -222,17 +222,17 @@ By default, if the app is open (in the foreground) when a notification arrives, 
 
 ```yaml
 automation:
-  - alias: Notify Mobile app
+  - alias: Notify Mobile app presentation
     trigger:
       ...
     action:
-      service: notify.ALL_DEVICES
-      data:
-        message: "Something happened at home!"
+      - service: notify.ALL_DEVICES
         data:
-          presentation_options:
-            - alert
-            - badge
+          message: "Something happened at home!"
+          data:
+            presentation_options:
+              - alert
+              - badge
 ```
 
 ### Notification Color
@@ -242,16 +242,16 @@ In Android you can set the `color` of the notification, you can use either the c
 
 ```yaml
 automation:
-  - alias: Notify of Motion
+  - alias: Notify of Motion color
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: "Motion Detected in Backyard"
-        message: "Someone might be in the backyard."
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          color: '#2DF56D' # or 'red'
+          title: "Motion Detected in Backyard"
+          message: "Someone might be in the backyard."
+          data:
+            color: '#2DF56D' # or 'red'
 ```
 
 ### Sticky Notification
@@ -261,16 +261,16 @@ You can set whether to dismiss the notification upon selecting it or not. Settin
 
 ```yaml
 automation:
-  - alias: Notify of Motion
+  - alias: Notify of Motion sticky
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: "Motion Detected in Backyard"
-        message: "Someone might be in the backyard."
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          sticky: 'true' # or 'false'
+          title: "Motion Detected in Backyard"
+          message: "Someone might be in the backyard."
+          data:
+            sticky: 'true' # or 'false'
 ```
 
 ### Notification Click Action
@@ -284,16 +284,16 @@ You can also trigger the More Info panel for any entity by using the following f
 
 ```yaml
 automation:
-  - alias: Notify of Motion
+  - alias: Notify of Motion click action
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: "Motion Detected in Backyard"
-        message: "Someone might be in the backyard."
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          clickAction: 'https://google.com' # action when clicking main notification
+          title: "Motion Detected in Backyard"
+          message: "Someone might be in the backyard."
+          data:
+            clickAction: 'https://google.com' # action when clicking main notification
 ```
 
 ### Notification Channels
@@ -309,16 +309,16 @@ In the example below a new channel will be created with the name `Motion`:
 
 ```yaml
 automation:
-  - alias: Notify of Motion
+  - alias: Notify of Motion channel
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: "Motion Detected in Backyard"
-        message: "Someone might be in the backyard."
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          channel: Motion # name of the channel you wish to create or utilize
+          title: "Motion Detected in Backyard"
+          message: "Someone might be in the backyard."
+          data:
+            channel: Motion # name of the channel you wish to create or utilize
 ```
 
 Default values for a channel if not provided will be as follows:
@@ -339,11 +339,11 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: remove_channel
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          channel: Motion # name of the channel you wish to remove
+          message: remove_channel
+          data:
+            channel: Motion # name of the channel you wish to remove
 ```
 
 #### Specific channel properties
@@ -367,16 +367,17 @@ When you are setting the `channel` for your notification you also have the optio
 See [Specific channel properties](#specific-channel-properties) for important behavior of this property.
 
 ```yaml
-  - alias: Notify of Motion
+automation:
+  - alias: Notify of Motion channel importance
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: Motion Detected
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          channel: Motion # For devices on Android 8.0+ only
-          importance: high
+          message: Motion Detected
+          data:
+            channel: Motion # For devices on Android 8.0+ only
+            importance: high
 ```
 
 ### Notification Vibration Pattern 
@@ -387,16 +388,17 @@ You can set the vibration pattern for the `channel` by setting the `vibrationPat
 See [Specific channel properties](#specific-channel-properties) for important behavior of this property.
 
 ```yaml
-  - alias: Notify of Motion
+automation:
+  - alias: Notify of Motion vibration
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: Motion Detected
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          vibrationPattern: "100, 1000, 100, 1000, 100" # The pattern you wish to set for vibrations
-          channel: Motion # For devices on Android 8.0+ only
+          message: Motion Detected
+          data:
+            vibrationPattern: "100, 1000, 100, 1000, 100" # The pattern you wish to set for vibrations
+            channel: Motion # For devices on Android 8.0+ only
 ```
 
 ### Notification LED Color
@@ -407,16 +409,17 @@ Some Android devices have a multi-color notification LED.  By setting the `ledCo
 See [Specific channel properties](#specific-channel-properties) for important behavior of this property.
 
 ```yaml
-  - alias: Notify of Motion
+automation:
+  - alias: Notify of Motion LED color
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: Motion detected
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          ledColor: "red" # Set the LED to red
-          channel: Motion # For devices on Android 8.0+ only          
+          message: Motion detected
+          data:
+            ledColor: "red" # Set the LED to red
+            channel: Motion # For devices on Android 8.0+ only          
 ```
 
 ### Persistent Notification
@@ -427,30 +430,32 @@ Persistent notifications are notifications that cannot be dimissed by swiping aw
 In the example below we will create a notification and then later on we will remove it.
 
 ```yaml
-  - alias: Notify of Motion
+automation:
+  - alias: Notify of Motion persistent
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: Motion detected
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          persistent: true # Set to true to create a persistent notification
-          tag: persistent # Tag is required for the persistent notification
+          message: Motion detected
+          data:
+            persistent: true # Set to true to create a persistent notification
+            tag: persistent # Tag is required for the persistent notification
 ```
 
 To remove the persistent notification we send `clear_notification` to the `tag` that we defined.
 
 ```yaml
-  - alias: Notify of Motion
+automation:
+  - alias: Notify of Motion persistent remove
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: clear_notification
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          tag: persistent # The tag for the persistent notification you wish to clear
+          message: clear_notification
+          data:
+            tag: persistent # The tag for the persistent notification you wish to clear
 ```
 
 ### Notification Subject
@@ -459,16 +464,17 @@ To remove the persistent notification we send `clear_notification` to the `tag` 
 If your notification is going to have a lot of text (more than 6 lines) you can opt to show smaller text by setting the `subject`.
 
 ```yaml
-  - alias: Notify of Motion
+automation:
+  - alias: Notify of Motion subject
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
-        title: "Long text"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          subject: "Subject for long text"
+          message: "Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet."
+          title: "Long text"
+          data:
+            subject: "Subject for long text"
 ```
 
 ### Notification Timeout
@@ -477,15 +483,16 @@ If your notification is going to have a lot of text (more than 6 lines) you can 
 You can set how long a notification will be shown on a users device before being removed/dismissed automatically. You may use the `timeout` property along with the value in seconds to achieve this.
 
 ```yaml
-  - alias: Notify of Motion
+automation:
+  - alias: Notify of Motion timeout
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: Motion Detected
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          timeout: 600 # How many seconds the notification should be received by the device
+          message: Motion Detected
+          data:
+            timeout: 600 # How many seconds the notification should be received by the device
 ```
 
 ### Notification Message HTML Formatting
@@ -494,14 +501,15 @@ You can set how long a notification will be shown on a users device before being
 You can add some custom HTML tags to the `message` of your notification.
 
 ```yaml
-  - alias: Notify of Motion
+automation:
+  - alias: Notify of Motion html
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: 'This is a <b><span style="color: red">HTML</span></b> <i>text</i><br><br>This is a text after a new line'
-        title: "Cool HTML formatting"
+      - service: notify.mobile_app_<your_device_id_here>
+        data:
+          message: 'This is a <b><span style="color: red">HTML</span></b> <i>text</i><br><br>This is a text after a new line'
+          title: "Cool HTML formatting"
 ```
 
 ### Notification Icon
@@ -510,15 +518,16 @@ You can add some custom HTML tags to the `message` of your notification.
 You can set the icon for a notification by providing the `icon_url`. The URL provided must be either publicly accessible or can be a relative path (i.e. `/local/icon/icon.png`), more details can be found in [attachments](attachments.md). It is important to note that if you set the `image` then Android will not show the icon for the notification, the `image` will be shown in its place. So the `message` will be shown with the `image` and with the image as the icon.
 
 ```yaml
-  - alias: Notify of Motion
+automation:
+  - alias: Notify of Motion icon
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: Motion Detected
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          icon_url: "https://github.com/home-assistant/home-assistant-assets/blob/master/logo-round-192x192.png?raw=true"
+          message: Motion Detected
+          data:
+            icon_url: "https://github.com/home-assistant/home-assistant-assets/blob/master/logo-round-192x192.png?raw=true"
 ```
 
 ### Text To Speech Notifications
@@ -527,50 +536,54 @@ You can set the icon for a notification by providing the `icon_url`. The URL pro
 Instead of posting a notification on the device you can instead get your device to speak the notification. This notification works different than the others. You will set `message: TTS` and the actual text to speak would be in the `title`. Current support is limited to the current Text To Speech locale set on the device. If there is an error processing the message you will see a toast message appear on the device. Check to make sure that the [Google Text To Speech](https://play.google.com/store/apps/details?id=com.google.android.tts) engine is up to date and set as the default, in case you run into any issues.
 
 ```yaml
-  - alias: Notify of Motion
+automation:
+  - alias: Notify of Motion TTS
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: TTS
-        title: Motion has been detected
+      - service: notify.mobile_app_<your_device_id_here>
+        data:
+          message: TTS
+          title: Motion has been detected
 ```
 
 By default Text To Speech notifications use the music stream so they will bypass the ringer mode on the device as long as the device's volume is not set to 0. You have the option of using `channel: alarm_stream` to have your notification spoken regardless of music volume.
 
 ```yaml
-  - alias: Notify of Motion
+automation:
+  - alias: Notify of Motion TTS alarm
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: TTS
-        title: Motion has been detected
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          channel: alarm_stream
+          message: TTS
+          title: Motion has been detected
+          data:
+            channel: alarm_stream
 ```
 
 If you find that your alarm stream volume is too low you can use `channel: alarm_stream_max` which will temporarily set the alarm stream volume to the max level, play the notification and then revert back to the original volume level.
 
 ```yaml
+automation:
   - alias: Notify Alarm Triggered
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: TTS
-        title: Alarm has been triggered
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          channel: alarm_stream_max
+          message: TTS
+          title: Alarm has been triggered
+          data:
+            channel: alarm_stream_max
 ```
 
 You may not want the TTS notification to be spoken in certain situations (e.g. if the Ringer mode is not `normal` or DND is enabled). This can be done by adding a condition in your automation that checks the state of [other sensors](https://companion.home-assistant.io/docs/core/sensors). Few examples are presented below:
 
 ```yaml
-  - alias: Notify of Motion
+automation:
+  - alias: Notify of Motion with conditions
     trigger:
       ...
     condition:
@@ -605,16 +618,17 @@ You may want to utilize [notification timeouts](#notification-timeout) or [repla
 - when - the timestamp to count up or down to (seconds since 01/01/1970)
 
 ```yaml
+automation:
   - alias: Notify of Next Alarm Time
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: Next Alarm
-        message: >-
-          Next Alarm At {{ states('sensor.<your_device_id_here>_next_alarm') }}
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          chronometer: true
-          when: "1609459200"
+          title: Next Alarm
+          message: >-
+            Next Alarm At {{ states('sensor.<your_device_id_here>_next_alarm') }}
+          data:
+            chronometer: true
+            when: "1609459200"
 ```

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -13,7 +13,7 @@ automation:
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          message: 'Notification text'
+          message: "Notification text"
 ```
 
 The mobile_app platform provides many enhancements to the simple notification generated above. The image below, for example, shows an [iOS actionable notification](actionable.md) allowing you to trigger different automations from each button.
@@ -28,7 +28,7 @@ If you include a URL in your notification, tapping on the notification will open
 
 ```yaml
 automation:
-  - alias: 'Send Notification with link'
+  - alias: "Send Notification with a link"
     trigger:
       ...
     action:
@@ -71,7 +71,7 @@ You can set the app icon badge in the payload. The below example will make the a
 
 ```yaml
 automation:
-  - alias: Notify Mobile app update badge
+  - alias: "Notify Mobile app update badge"
     trigger:
       ...
     action:
@@ -92,7 +92,7 @@ A subtitle is supported in addition to the title:
 
 ```yaml
 automation:
-  - alias: Notify Mobile app subtitle
+  - alias: "Notify Mobile app subtitle"
     trigger:
       ...
     action:
@@ -110,7 +110,7 @@ Grouping of notifications is supported on iOS 12 and above. All notifications wi
 
 ```yaml
 automation:
-  - alias: Notify Mobile app grouping
+  - alias: "Notify Mobile app grouping"
     trigger:
       ...
     action:
@@ -134,9 +134,9 @@ automation:
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          message: Motion detected
+          message: "Motion detected"
           data:
-            group: Motion # name of the group you wish to use
+            group: "Motion" # name of the group you wish to use
 ```
 
 ### Replacing notifications
@@ -145,7 +145,7 @@ Existing notifications can be replaced using `apns-collapse-id`. This will conti
 
 ```yaml
 automation:
-  - alias: Notify of Motion iOS replacement
+  - alias: "Notify of Motion iOS replacement"
     trigger:
       ...
     action:
@@ -155,7 +155,7 @@ automation:
           message: "Someone might be in the backyard."
           data:
             apns_headers:
-              apns-collapse-id: 'backyard-motion-detected'
+              apns-collapse-id: "backyard-motion-detected"
 ```
 
 ![Android](/assets/android.svg)<br />
@@ -163,7 +163,7 @@ For Android users you can easily replace the notification using the `tag` servic
 
 ```yaml
 automation:
-  - alias: Notify of Motion android replacement
+  - alias: "Notify of Motion Android replacement"
     trigger:
       ...
     action:
@@ -172,7 +172,7 @@ automation:
           title: "Motion Detected in Backyard"
           message: "Someone might be in the backyard."
           data:
-            tag: tag
+            tag: "tag"
 ```
 
 ![Android](/assets/android.svg)<br />
@@ -180,15 +180,15 @@ You can also remove a notification by sending `clear_notification` to the same `
 
 ```yaml
 automation:
-  - alias: Notify of Motion clear notification
+  - alias: "Notify of Motion clear notification"
     trigger:
       ...
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          message: clear_notification
+          message: "clear_notification"
           data:
-            tag: tag
+            tag: "tag"
 ```
 
 ### Sending notifications to multiple devices
@@ -207,7 +207,7 @@ notify:
 Now, you can send notifications to everyone in the group using.  If you plan to group Android and iOS devices only `message` and `title` will work:
 ```yaml
   automation:
-    - alias: Notify Mobile app group
+    - alias: "Notify Mobile app group"
       trigger:
         ...
       action:
@@ -222,7 +222,7 @@ By default, if the app is open (in the foreground) when a notification arrives, 
 
 ```yaml
 automation:
-  - alias: Notify Mobile app presentation
+  - alias: "Notify Mobile app presentation"
     trigger:
       ...
     action:
@@ -242,7 +242,7 @@ In Android you can set the `color` of the notification, you can use either the c
 
 ```yaml
 automation:
-  - alias: Notify of Motion color
+  - alias: "Notify of Motion color"
     trigger:
       ...
     action:
@@ -251,7 +251,7 @@ automation:
           title: "Motion Detected in Backyard"
           message: "Someone might be in the backyard."
           data:
-            color: '#2DF56D' # or 'red'
+            color: "#2DF56D" # or "red"
 ```
 
 ### Sticky Notification
@@ -261,7 +261,7 @@ You can set whether to dismiss the notification upon selecting it or not. Settin
 
 ```yaml
 automation:
-  - alias: Notify of Motion sticky
+  - alias: "Notify of Motion sticky"
     trigger:
       ...
     action:
@@ -270,7 +270,7 @@ automation:
           title: "Motion Detected in Backyard"
           message: "Someone might be in the backyard."
           data:
-            sticky: 'true' # or 'false'
+            sticky: "true" # or "false"
 ```
 
 ### Notification Click Action
@@ -284,7 +284,7 @@ You can also trigger the More Info panel for any entity by using the following f
 
 ```yaml
 automation:
-  - alias: Notify of Motion click action
+  - alias: "Notify of Motion click action"
     trigger:
       ...
     action:
@@ -293,7 +293,7 @@ automation:
           title: "Motion Detected in Backyard"
           message: "Someone might be in the backyard."
           data:
-            clickAction: 'https://google.com' # action when clicking main notification
+            clickAction: "https://google.com" # Action when clicking main notification
 ```
 
 ### Notification Channels
@@ -309,7 +309,7 @@ In the example below a new channel will be created with the name `Motion`:
 
 ```yaml
 automation:
-  - alias: Notify of Motion channel
+  - alias: "Notify of Motion channel"
     trigger:
       ...
     action:
@@ -318,7 +318,7 @@ automation:
           title: "Motion Detected in Backyard"
           message: "Someone might be in the backyard."
           data:
-            channel: Motion # name of the channel you wish to create or utilize
+            channel: "Motion" # Name of the channel you wish to create or utilize
 ```
 
 Default values for a channel if not provided will be as follows:
@@ -341,9 +341,9 @@ automation:
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          message: remove_channel
+          message: "remove_channel"
           data:
-            channel: Motion # name of the channel you wish to remove
+            channel: "Motion" # Name of the channel you wish to remove
 ```
 
 #### Specific channel properties
@@ -368,15 +368,15 @@ See [Specific channel properties](#specific-channel-properties) for important be
 
 ```yaml
 automation:
-  - alias: Notify of Motion channel importance
+  - alias: "Notify of Motion channel importance"
     trigger:
       ...
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          message: Motion Detected
+          message: "Motion Detected"
           data:
-            channel: Motion # For devices on Android 8.0+ only
+            channel: "Motion" # For devices on Android 8.0+ only
             importance: high
 ```
 
@@ -389,16 +389,16 @@ See [Specific channel properties](#specific-channel-properties) for important be
 
 ```yaml
 automation:
-  - alias: Notify of Motion vibration
+  - alias: "Notify of Motion vibration"
     trigger:
       ...
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          message: Motion Detected
+          message: "Motion Detected"
           data:
             vibrationPattern: "100, 1000, 100, 1000, 100" # The pattern you wish to set for vibrations
-            channel: Motion # For devices on Android 8.0+ only
+            channel: "Motion" # For devices on Android 8.0+ only
 ```
 
 ### Notification LED Color
@@ -410,7 +410,7 @@ See [Specific channel properties](#specific-channel-properties) for important be
 
 ```yaml
 automation:
-  - alias: Notify of Motion LED color
+  - alias: "Notify of Motion LED color"
     trigger:
       ...
     action:
@@ -419,7 +419,7 @@ automation:
           message: Motion detected
           data:
             ledColor: "red" # Set the LED to red
-            channel: Motion # For devices on Android 8.0+ only          
+            channel: "Motion" # For devices on Android 8.0+ only
 ```
 
 ### Persistent Notification
@@ -431,31 +431,31 @@ In the example below we will create a notification and then later on we will rem
 
 ```yaml
 automation:
-  - alias: Notify of Motion persistent
+  - alias: "Notify of Motion persistent"
     trigger:
       ...
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          message: Motion detected
+          message: "Motion detected"
           data:
             persistent: true # Set to true to create a persistent notification
-            tag: persistent # Tag is required for the persistent notification
+            tag: "persistent" # Tag is required for the persistent notification
 ```
 
 To remove the persistent notification we send `clear_notification` to the `tag` that we defined.
 
 ```yaml
 automation:
-  - alias: Notify of Motion persistent remove
+  - alias: "Notify of Motion persistent remove"
     trigger:
       ...
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          message: clear_notification
+          message: "clear_notification"
           data:
-            tag: persistent # The tag for the persistent notification you wish to clear
+            tag: "persistent" # The tag for the persistent notification you wish to clear
 ```
 
 ### Notification Subject
@@ -465,7 +465,7 @@ If your notification is going to have a lot of text (more than 6 lines) you can 
 
 ```yaml
 automation:
-  - alias: Notify of Motion subject
+  - alias: "Notify of Motion subject"
     trigger:
       ...
     action:
@@ -484,13 +484,13 @@ You can set how long a notification will be shown on a users device before being
 
 ```yaml
 automation:
-  - alias: Notify of Motion timeout
+  - alias: "Notify of Motion timeout"
     trigger:
       ...
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          message: Motion Detected
+          message: "Motion Detected"
           data:
             timeout: 600 # How many seconds the notification should be received by the device
 ```
@@ -502,13 +502,14 @@ You can add some custom HTML tags to the `message` of your notification.
 
 ```yaml
 automation:
-  - alias: Notify of Motion html
+  - alias: "Notify of Motion HTML"
     trigger:
       ...
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          message: 'This is a <b><span style="color: red">HTML</span></b> <i>text</i><br><br>This is a text after a new line'
+          message: >
+          	This is a <b><span style="color: red">HTML</span></b> <i>text</i><br><br>This is a text after a new line
           title: "Cool HTML formatting"
 ```
 
@@ -519,13 +520,13 @@ You can set the icon for a notification by providing the `icon_url`. The URL pro
 
 ```yaml
 automation:
-  - alias: Notify of Motion icon
+  - alias: "Notify of Motion icon"
     trigger:
       ...
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          message: Motion Detected
+          message: "Motion Detected"
           data:
             icon_url: "https://github.com/home-assistant/home-assistant-assets/blob/master/logo-round-192x192.png?raw=true"
 ```
@@ -543,47 +544,47 @@ automation:
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          message: TTS
-          title: Motion has been detected
+          message: "TTS"
+          title: "Motion has been detected"
 ```
 
 By default Text To Speech notifications use the music stream so they will bypass the ringer mode on the device as long as the device's volume is not set to 0. You have the option of using `channel: alarm_stream` to have your notification spoken regardless of music volume.
 
 ```yaml
 automation:
-  - alias: Notify of Motion TTS alarm
+  - alias: "Notify of Motion TTS alarm"
     trigger:
       ...
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
           message: TTS
-          title: Motion has been detected
+          title: "Motion has been detected"
           data:
-            channel: alarm_stream
+            channel: "alarm_stream"
 ```
 
 If you find that your alarm stream volume is too low you can use `channel: alarm_stream_max` which will temporarily set the alarm stream volume to the max level, play the notification and then revert back to the original volume level.
 
 ```yaml
 automation:
-  - alias: Notify Alarm Triggered
+  - alias: "Notify Alarm Triggered"
     trigger:
       ...
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          message: TTS
-          title: Alarm has been triggered
+          message: "TTS"
+          title: "Alarm has been triggered"
           data:
-            channel: alarm_stream_max
+            channel: "alarm_stream_max"
 ```
 
 You may not want the TTS notification to be spoken in certain situations (e.g. if the Ringer mode is not `normal` or DND is enabled). This can be done by adding a condition in your automation that checks the state of [other sensors](https://companion.home-assistant.io/docs/core/sensors). Few examples are presented below:
 
 ```yaml
 automation:
-  - alias: Notify of Motion with conditions
+  - alias: "Notify of Motion with conditions"
     trigger:
       ...
     condition:
@@ -625,7 +626,7 @@ automation:
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          title: Next Alarm
+          title: "Next Alarm"
           message: >-
             Next Alarm At {{ states('sensor.<your_device_id_here>_next_alarm') }}
           data:

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -168,7 +168,7 @@ automation:
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          message: command_broadcast_intent
+          message: "command_broadcast_intent"
           title: "com.urbandroid.sleep.alarmclock.ALARM_STATE_CHANGE"
           data:
             channel: "com.urbandroid.sleep"
@@ -295,7 +295,7 @@ automation:
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          message: command_screen_on
+          message: "command_screen_on"
 ```
 
 
@@ -325,7 +325,7 @@ automation:
           message: "command_volume_level"
           title: 20
           data:
-            channel: music_stream
+            channel: "music_stream"
 ```
 
 ## Webview

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -53,13 +53,13 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "command_activity"
-        title: "google.navigation:q=arbys"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          channel: "com.google.android.apps.maps"
-          tag: "android.intent.action.VIEW"
+          message: "command_activity"
+          title: "google.navigation:q=arbys"
+          data:
+            channel: "com.google.android.apps.maps"
+            tag: "android.intent.action.VIEW"
 ```
 
 To continue with the above example you can also launch [search results](https://developer.android.com/guide/components/intents-common#Maps) with the following:
@@ -70,13 +70,13 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "command_activity"
-        title: "geo:0,0?q=1600+Amphitheatre+Parkway%2C+CA"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          channel: "com.google.android.apps.maps"
-          tag: "android.intent.action.VIEW"
+          message: "command_activity"
+          title: "geo:0,0?q=1600+Amphitheatre+Parkway%2C+CA"
+          data:
+            channel: "com.google.android.apps.maps"
+            tag: "android.intent.action.VIEW"
 ```
 
 ## BLE Beacon Transmitter
@@ -93,10 +93,10 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "command_ble_transmitter"
-        title: "turn_off"
+      - service: notify.mobile_app_<your_device_id_here>
+        data:
+          message: "command_ble_transmitter"
+          title: "turn_off"
 ```
 
 
@@ -114,10 +114,10 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "command_bluetooth"
-        title: "turn_off"
+      - service: notify.mobile_app_<your_device_id_here>
+        data:
+          message: "command_bluetooth"
+          title: "turn_off"
 ```
 
 ## Broadcast Intent
@@ -134,12 +134,12 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "command_broadcast_intent"
-        title: "action"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          channel: "package-name"
+          message: "command_broadcast_intent"
+          title: "action"
+          data:
+            channel: "package-name"
 ```
 
 An example of an application that accepts broadcast intents is [Sleep as Android](https://docs.sleep.urbandroid.org/devs/intent_api.html#action-intents-to-control-sleep). To start a sleep tracking event the format would be as follows:
@@ -150,12 +150,12 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "command_broadcast_intent"
-        title: "com.urbandroid.sleep.alarmclock.START_SLEEP_TRACK"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          channel: "com.urbandroid.sleep"
+          message: "command_broadcast_intent"
+          title: "com.urbandroid.sleep.alarmclock.START_SLEEP_TRACK"
+          data:
+            channel: "com.urbandroid.sleep"
 ```
 
 [Extras](https://developer.android.com/reference/android/content/Intent#putExtra(java.lang.String,%20java.lang.String)) are also supported under the `group` parameter. As there can be any number of extras added to the intent we will need to split each extra by a comma `,`. Then each extra name and value needs to be separated by a colon `:`. The below example shows you how to turn on an alarm labeled `work` in the Sleep as Android application. In this example there are 2 extras being added to the intent.
@@ -166,13 +166,13 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: command_broadcast_intent
-        title: "com.urbandroid.sleep.alarmclock.ALARM_STATE_CHANGE"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          channel: "com.urbandroid.sleep"
-          group: "alarm_label:work,alarm_enabled:false"
+          message: command_broadcast_intent
+          title: "com.urbandroid.sleep.alarmclock.ALARM_STATE_CHANGE"
+          data:
+            channel: "com.urbandroid.sleep"
+            group: "alarm_label:work,alarm_enabled:false"
 ```
 
 ## Do Not Disturb
@@ -200,10 +200,10 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "command_dnd"
-        title: "priority_only"
+      - service: notify.mobile_app_<your_device_id_here>
+        data:
+          message: "command_dnd"
+          title: "priority_only"
 ```
 
 
@@ -221,10 +221,10 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "command_high_accuracy_mode"
-        title: "turn_off"
+      - service: notify.mobile_app_<your_device_id_here>
+        data:
+          message: "command_high_accuracy_mode"
+          title: "turn_off"
 ```
 
 
@@ -243,9 +243,9 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "request_location_update"
+      - service: notify.mobile_app_<your_device_id_here>
+        data:
+          message: "request_location_update"
 ```
 
 Assuming the device receives the notification, it will attempt to get a location update within 5 seconds and report it to Home Assistant. This is a little bit hit or miss since Apple imposes a maximum time allowed for the app to work with the notification and location updates sometimes take longer than usual due to factors such as waiting for GPS acquisition.
@@ -275,10 +275,10 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "command_ringer_mode"
-        title: "vibrate"
+      - service: notify.mobile_app_<your_device_id_here>
+        data:
+          message: "command_ringer_mode"
+          title: "vibrate"
 ```
 
 ## Screen On
@@ -293,9 +293,9 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: command_screen_on
+      - service: notify.mobile_app_<your_device_id_here>
+        data:
+          message: command_screen_on
 ```
 
 
@@ -320,12 +320,12 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "command_volume_level"
-        title: 20
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          channel: music_stream
+          message: "command_volume_level"
+          title: 20
+          data:
+            channel: music_stream
 ```
 
 ## Webview
@@ -342,8 +342,8 @@ automation:
     trigger:
       ...
     action:
-      service: notify.mobile_app_<your_device_id_here>
-      data:
-        message: "command_webview"
-        title: "/lovelace/settings"
+      - service: notify.mobile_app_<your_device_id_here>
+        data:
+          message: "command_webview"
+          title: "/lovelace/settings"
 ```

--- a/docs/notifications/critical.md
+++ b/docs/notifications/critical.md
@@ -13,11 +13,13 @@ iOS gives special priority to this type of notification. Critical alerts always 
 
 ```yaml
 automations:
-  - alias: 'Fire Detected iOS'
+  - alias: "Fire Detected iOS"
+
     trigger:
       - platform: state
         entity_id: sensor.smoke_alarm
-        to: 'smoke'
+        to: "smoke"
+
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
@@ -26,7 +28,8 @@ automations:
           data:
             push:
               sound:
-                name: default
+                name: "default"
+
                 critical: 1
                 volume: 1.0
 
@@ -42,11 +45,13 @@ For Android these notifications are designed to show up on the phone immediately
 
 ```yaml
 automations:
-  - alias: 'Fire Detected android'
+  - alias: "Fire Detected android"
+
     trigger:
       - platform: state
         entity_id: sensor.smoke_alarm
-        to: 'smoke'
+        to: "smoke"
+
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
@@ -64,11 +69,12 @@ Using this method to can send a normal notification:
 
 ```yaml
 automations:
-  - alias: 'Fire Detected android alarm stream'
+  - alias: "Fire Detected Android alarm stream"
     trigger:
       - platform: state
         entity_id: sensor.smoke_alarm
-        to: 'smoke'
+        to: "smoke"
+
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
@@ -84,11 +90,12 @@ Or you can use Text To Speech to speak the notification:
 
 ```yaml
 automations:
-  - alias: 'Fire Detected TTS alarm'
+  - alias: "Fire Detected TTS alarm"
+
     trigger:
       - platform: state
         entity_id: sensor.smoke_alarm
-        to: 'smoke'
+        to: "smoke"
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
@@ -104,16 +111,18 @@ Alternatively using Text To Speech you can also make the notification speak as l
 
 ```yaml
 automations:
-  - alias: 'Fire Detected TTS loud'
+  - alias: "Fire Detected TTS loud"
+
     trigger:
       - platform: state
         entity_id: sensor.smoke_alarm
-        to: 'smoke'
+        to: "smoke"
+
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
           title: "The house is on fire and the cat's stuck in the dryer!"
-          message: TTS
+          message: "TTS"
           data:
             ttl: 0
             priority: high

--- a/docs/notifications/critical.md
+++ b/docs/notifications/critical.md
@@ -13,22 +13,22 @@ iOS gives special priority to this type of notification. Critical alerts always 
 
 ```yaml
 automations:
-  - alias: 'Fire Detected'
+  - alias: 'Fire Detected iOS'
     trigger:
-    - platform: state
-      entity_id: sensor.smoke_alarm
-      to: 'smoke'
+      - platform: state
+        entity_id: sensor.smoke_alarm
+        to: 'smoke'
     action:
-    - service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: "Wake up!"
-        message: "The house is on fire and the cat's stuck in the dryer!"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          push:
-            sound:
-              name: default
-              critical: 1
-              volume: 1.0
+          title: "Wake up!"
+          message: "The house is on fire and the cat's stuck in the dryer!"
+          data:
+            push:
+              sound:
+                name: default
+                critical: 1
+                volume: 1.0
 
 ```
 If you have previously read the [sounds documentation](sounds.md) this syntax should be mostly familiar. Note the example expands the `sound` attribute to include the `critical: 1` flag, and `volume: 1.0` to set the volume to 100 %.
@@ -42,19 +42,19 @@ For Android these notifications are designed to show up on the phone immediately
 
 ```yaml
 automations:
-  - alias: 'Fire Detected'
+  - alias: 'Fire Detected android'
     trigger:
-    - platform: state
-      entity_id: sensor.smoke_alarm
-      to: 'smoke'
+      - platform: state
+        entity_id: sensor.smoke_alarm
+        to: 'smoke'
     action:
-    - service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: "Wake up!"
-        message: "The house is on fire and the cat's stuck in the dryer!"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          ttl: 0
-          priority: high
+          title: "Wake up!"
+          message: "The house is on fire and the cat's stuck in the dryer!"
+          data:
+            ttl: 0
+            priority: high
 ```
 
 ![Android](/assets/android.svg)<br />
@@ -64,58 +64,58 @@ Using this method to can send a normal notification:
 
 ```yaml
 automations:
-  - alias: 'Fire Detected'
+  - alias: 'Fire Detected android alarm stream'
     trigger:
-    - platform: state
-      entity_id: sensor.smoke_alarm
-      to: 'smoke'
+      - platform: state
+        entity_id: sensor.smoke_alarm
+        to: 'smoke'
     action:
-    - service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: "Wake up!"
-        message: "The house is on fire and the cat's stuck in the dryer!"
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          ttl: 0
-          priority: high
-          channel: alarm_stream
+          title: "Wake up!"
+          message: "The house is on fire and the cat's stuck in the dryer!"
+          data:
+            ttl: 0
+            priority: high
+            channel: alarm_stream
 ```
 
 Or you can use Text To Speech to speak the notification:
 
 ```yaml
 automations:
-  - alias: 'Fire Detected'
+  - alias: 'Fire Detected TTS alarm'
     trigger:
-    - platform: state
-      entity_id: sensor.smoke_alarm
-      to: 'smoke'
+      - platform: state
+        entity_id: sensor.smoke_alarm
+        to: 'smoke'
     action:
-    - service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: "The house is on fire and the cat's stuck in the dryer!"
-        message: TTS
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          ttl: 0
-          priority: high
-          channel: alarm_stream
+          title: "The house is on fire and the cat's stuck in the dryer!"
+          message: TTS
+          data:
+            ttl: 0
+            priority: high
+            channel: alarm_stream
 ```
 
 Alternatively using Text To Speech you can also make the notification speak as loud as it can, and then revert back to the original volume level:
 
 ```yaml
 automations:
-  - alias: 'Fire Detected'
+  - alias: 'Fire Detected TTS loud'
     trigger:
-    - platform: state
-      entity_id: sensor.smoke_alarm
-      to: 'smoke'
+      - platform: state
+        entity_id: sensor.smoke_alarm
+        to: 'smoke'
     action:
-    - service: notify.mobile_app_<your_device_id_here>
-      data:
-        title: "The house is on fire and the cat's stuck in the dryer!"
-        message: TTS
+      - service: notify.mobile_app_<your_device_id_here>
         data:
-          ttl: 0
-          priority: high
-          channel: alarm_stream_max
+          title: "The house is on fire and the cat's stuck in the dryer!"
+          message: TTS
+          data:
+            ttl: 0
+            priority: high
+            channel: alarm_stream_max
 ```

--- a/docs/notifications/sounds.md
+++ b/docs/notifications/sounds.md
@@ -9,16 +9,17 @@ Adding a custom sound to a notification allows you to easily identify the notifi
 Here is an example notification that uses one of the pre-installed sounds.
 
 ```yaml
-- alias: Notify Mobile App
+automation:
+- alias: Notify Mobile App sound
   trigger:
     ...
   action:
-    service: notify.mobile_app_<your_device_id_here>
-    data:
-      message: “Your Roommate arrived”
+    - service: notify.mobile_app_<your_device_id_here>
       data:
-        push:
-          sound: "US-EN-Morgan-Freeman-Roommate-Is-Arriving.wav"
+        message: “Your Roommate arrived”
+        data:
+          push:
+            sound: "US-EN-Morgan-Freeman-Roommate-Is-Arriving.wav"
 ```
 
 > You must use the full filename (including extension) in the payload.

--- a/docs/notifications/sounds.md
+++ b/docs/notifications/sounds.md
@@ -10,7 +10,7 @@ Here is an example notification that uses one of the pre-installed sounds.
 
 ```yaml
 automation:
-- alias: Notify Mobile App sound
+- alias: "Notify Mobile App sound"
   trigger:
     ...
   action:


### PR DESCRIPTION
Per a review comment from @frenck https://github.com/home-assistant/companion.home-assistant/pull/494#discussion_r613502866 he had pointed out that most of our YAML examples were not following the style guide.

I have gone through and updated as many as I can find

https://developers.home-assistant.io/docs/documenting/yaml-style-guide/