### PR TITLE
Handle inversion and code links in admonitions

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -67,6 +67,17 @@ html[data-theme='dark'] .invertDark {
   filter: invert(1.0)
 }
 
+html[data-theme='dark'] article .admonition-note img[alt='Android'],
+html[data-theme='dark'] article .admonition-info img[alt='Android'],
+html[data-theme='dark'] article .admonition-note img[alt='iOS'],
+html[data-theme='dark'] article .admonition-info img[alt='iOS'],
+html[data-theme='dark'] article .admonition-note img[alt='macOS'],
+html[data-theme='dark'] article .admonition-info img[alt='macOS'],
+html[data-theme='dark'] article .admonition-note img[alt='Apple'],
+html[data-theme='dark'] article .admonition-info img[alt='Apple'] {
+  filter: invert(0.0)
+}
+
 .center_image {
   display:block;
   margin:auto;
@@ -81,4 +92,16 @@ html[data-theme='dark'] .invertDark {
 
 .beta:empty:before {
   content: "BETA";
+}
+
+.admonition-info a code {
+  color: var(--ifm-code-color);
+  text-decoration: underline;
+  text-decoration-color: var(--ifm-code-color);
+}
+
+.admonition-info a code:hover {
+  text-decoration: underline;
+  text-decoration-color: var(--ifm-code-background);
+  
 }


### PR DESCRIPTION
Just tidies up a couple of little low-contrast bugs in the styling of admonitions

## Before:
![image](https://user-images.githubusercontent.com/12411302/115303879-1f5a3200-a15c-11eb-99ce-616915f537a3.png)
![image](https://user-images.githubusercontent.com/12411302/115303975-3bf66a00-a15c-11eb-8951-dd3b47dd14a2.png)

## After:
![image](https://user-images.githubusercontent.com/12411302/115303910-284b0380-a15c-11eb-95ad-3e7e54dc136d.png)
![image](https://user-images.githubusercontent.com/12411302/115304002-47499580-a15c-11eb-8477-10b47984b72f.png)

