### PR TITLE
Update download badges

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -105,3 +105,9 @@ html[data-theme='dark'] article .admonition-info img[alt='Apple'] {
   text-decoration-color: var(--ifm-code-background);
   
 }
+
+.download-badge {
+  margin-left: auto;
+  margin-right: auto;
+  display: block;
+}

--- a/src/pages/download.js
+++ b/src/pages/download.js
@@ -1,9 +1,6 @@
-import React from 'react';
-import clsx from 'clsx';
 import Layout from '@theme/Layout';
-import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import useBaseUrl from '@docusaurus/useBaseUrl';
+import clsx from 'clsx';
+import React from 'react';
 import styles from './styles.module.css';
 
 
@@ -17,10 +14,12 @@ function Hello() {
           <h1 className="hero__title">Download the Home Assistant Apps</h1>
           <p className="hero__subtitle">Get the apps now!</p>
           <div className={clsx(styles.buttons, 'download-badges')} >
-          <a href="https://apps.apple.com/us/app/home-assistant/id1099568401?mt=8" style={{display:'inline-block', overflow: 'hidden', background: 'url(https://linkmaker.itunes.apple.com/en-us/badge-lrg.svg?releaseDate=2017-04-15&kind=iossoftware&bubble=apple_music) no-repeat center', width: '155px', height: '40px'}}></a>
-          <a href='https://play.google.com/store/apps/details?id=io.homeassistant.companion.android&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'>
-            <img alt='Get it on Google Play' width="155" src='https://play.google.com/intl/en_gb/badges/static/images/badges/en_badge_web_generic.png'/>
-          </a>
+            <a href="https://apps.apple.com/us/app/home-assistant/id1099568401?itsct=apps_box_badge&amp;itscg=30200">
+              <img width="163" src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1492214400&h=3ef4307fa479838e52fe9bd8bd17913b" alt="Download on the App Store" />
+            </a>
+            <a href='https://play.google.com/store/apps/details?id=io.homeassistant.companion.android&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'>
+              <img width="200" alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png' />
+            </a>
           </div>
         </div>
       </header>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,9 +1,9 @@
-import React from 'react';
-import clsx from 'clsx';
-import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
-import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import Layout from '@theme/Layout';
+import clsx from 'clsx';
+import React from 'react';
 import styles from './styles.module.css';
 
 const features = [
@@ -32,11 +32,14 @@ const features = [
     title: <>Get The Apps</>,
     description: (
       <>
-        <a href="https://apps.apple.com/us/app/home-assistant/id1099568401?mt=8" style={{ display: 'inline-block', overflow: 'hidden', background: 'url(https://linkmaker.itunes.apple.com/en-us/badge-lrg.svg?releaseDate=2017-04-15&kind=iossoftware&bubble=apple_music) no-repeat center', width: '155px', height: '40px' }}></a>
-        <br />
-        <a href='https://play.google.com/store/apps/details?id=io.homeassistant.companion.android&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'>
-          <img alt='Get it on Google Play' width="155" src='https://play.google.com/intl/en_gb/badges/static/images/badges/en_badge_web_generic.png' />
+        <a href='https://play.google.com/store/apps/details?id=io.homeassistant.companion.android&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1' style={{ display: 'inline-block' }}>
+          <img width="200" alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png' />
         </a>
+        <br />
+        <a href="https://apps.apple.com/us/app/home-assistant/id1099568401?itsct=apps_box_badge&amp;itscg=30200" style={{ display: 'inline-block', width: '200px' }}>
+          <img width="163" src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1492214400&h=3ef4307fa479838e52fe9bd8bd17913b" alt="Download on the App Store" />
+        </a>
+
         <h2>Source Code</h2>
         <ul>
           <li><a href="https://github.com/home-assistant/iOS">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -33,11 +33,11 @@ const features = [
     description: (
       <>
         <a href='https://play.google.com/store/apps/details?id=io.homeassistant.companion.android&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1' style={{ display: 'inline-block' }}>
-          <img width="200" alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png' />
+          <img width="200" class="download-badge" alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png' />
         </a>
         <br />
         <a href="https://apps.apple.com/us/app/home-assistant/id1099568401?itsct=apps_box_badge&amp;itscg=30200" style={{ display: 'inline-block', width: '200px' }}>
-          <img width="163" src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1492214400&h=3ef4307fa479838e52fe9bd8bd17913b" alt="Download on the App Store" />
+          <img class="download-badge" width="175" src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1492214400&h=3ef4307fa479838e52fe9bd8bd17913b" alt="Download on the App Store" />
         </a>
 
         <h2>Source Code</h2>


### PR DESCRIPTION
Apple's link maker is dead and so our old download link was empty. Updated both badges from their respective store's current link makers and massaged a little to make them appear roughly equal in size