### PR TITLE
fix: typo on media command link

### DIFF
--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -24,7 +24,7 @@ The Companion apps offer a lot of different notification options. In place of po
 | `command_broadcast_intent` | Send a broadcast intent to another app, [see below](#broadcast-intent) for how it works and whats required. |
 | `command_dnd` | Control Do Not Disturb mode on the device, [see below](#do-not-disturb) for how it works and whats required. |
 | `command_high_accuracy_mode` | Control the high accuracy mode of the background location sensor, [see below](#high-accuracy-mode) for how it works and whats required. |
-| `command_media` | Control media playing on the device, [see below](#meda) for how it works and whats required. &nbsp;<span class="beta">BETA</span><br /> |
+| `command_media` | Control media playing on the device, [see below](#media) for how it works and whats required. &nbsp;<span class="beta">BETA</span><br /> |
 | `command_ringer_mode` | Control the ringer mode on the device, [see below](#ringer-mode) for how it works and whats required. |
 | `command_screen_on` | Turn on the device screen. |
 | `command_volume_level` | Control the volume for all available audio streams, [see below](#volume-level) for how it works and whats required. |


### PR DESCRIPTION
Small typo I noticed when reading the docs.