### PR TITLE
Add page anchors for critical notifications to link easily to different examples

### DIFF
--- a/docs/notifications/critical.md
+++ b/docs/notifications/critical.md
@@ -4,7 +4,7 @@ id: "critical-notifications"
 ---
 The configuration and behavior of critical notifications differ between iOS and Android.
 
-![iOS](/assets/iOS.svg)<br />
+## ![iOS](/assets/iOS.svg)
 Critical notifications were introduced in iOS 12 and are designed for sending high-priority notifications that you don't want to miss - for example security system, water leak sensor, and smoke/CO2 alarm alerts.
 
 iOS gives special priority to this type of notification. Critical alerts always appear at the top of your lock screen above all other notifications, and play a sound even if Do Not Disturb is enabled or the iPhone is muted. Because we never want you to miss a critical notification, they are allowed to bypass the app [notification rate limits](details.md) as well.
@@ -37,7 +37,7 @@ If you have previously read the [sounds documentation](sounds.md) this syntax sh
 
 For **CarPlay** users, it's also worth mentioning that critical notifications are the only ones that can appear on the car's built-in display, making them very useful if you want to know when something critical happens while you're driving.
 
-![Android](/assets/android.svg)<br />
+## ![Android](/assets/android.svg)
 For Android these notifications are designed to show up on the phone immediately. By default they do not override Do Not Disturb settings, if you would like to override this you will need to use [notification channels](basic.md#notification-channels). 
 
 ![Android](/assets/android.svg) &nbsp; Android example
@@ -61,7 +61,7 @@ automations:
             priority: high
 ```
 
-![Android](/assets/android.svg)<br />
+### ![Android](/assets/android.svg) Alarm Stream
 You can also force the notification to play from the alarm stream so it will make the device ring even if on vibrate/silent ringer mode. Users on Android 7 and below can still use the `channel` example below as we are just using it to override the default notification behavior for sound. In order to make a notification show up immediately and make a sound regardless of ringer mode follow one of the examples below.
 
 Using this method to can send a normal notification:
@@ -85,6 +85,7 @@ automations:
             channel: alarm_stream
 ```
 
+### ![Android](/assets/android.svg) Text To Speech Alarm Stream
 Or you can use Text To Speech to speak the notification:
 
 ```yaml
@@ -105,7 +106,7 @@ automations:
             priority: high
             channel: alarm_stream
 ```
-
+### ![Android](/assets/android.svg) Text To Speech Alarm Stream Max Volume
 Alternatively using Text To Speech you can also make the notification speak as loud as it can, and then revert back to the original volume level:
 
 ```yaml


### PR DESCRIPTION
Should make it easier to link to specific examples instead of saying things like "3rd example down"