### PR TITLE
Update theming.md to include `primary-background-color` and `app-header-background-color` for android

### DIFF
--- a/docs/integrations/theming.md
+++ b/docs/integrations/theming.md
@@ -5,15 +5,16 @@ id: 'theming'
 
 ## Colors used
 
-![Android](/assets/android.svg) &nbsp; Android<br />
-- `primary-color` for the status bar background color ![Android](/assets/android.svg)
+![Android](/assets/android.svg) &nbsp; Android<br /><br />
 Colors should be specified in hex format (e.g. `#0099ff`) and defining element colors through variable names is not supported.
+- `primary-background-color` for the navigation bar background color ![Android](/assets/android.svg)
+- `app-header-background-color` for the status bar background color ![Android](/assets/android.svg)
 
-![iOS](/assets/iOS.svg)<br />
+![iOS](/assets/iOS.svg)<br /><br />
+As of version 2020.3, the iOS app will accept colors specified in hex, rgb, hsl, rgba, hsla formats or using a valid [HTML color name](https://www.w3schools.com/colors/colors_names.asp); although formats with alpha values are recognized, using alpha values less than 100 % (or 1) will currently lead to a color mismatch. 2020.2 and earlier versions of the app require colors to be specified in hex.
 - `primary-background-color` for the background color of the web view ![iOS](/assets/iOS.svg)
 - `app-header-background-color` for the status bar background color ![iOS](/assets/iOS.svg)
 - `primary-color` for the pull-to-refresh control/spinner ![iOS](/assets/iOS.svg)
-As of version 2020.3, the iOS app will accept colors specified in hex, rgb, hsl, rgba, hsla formats or using a valid [HTML color name](https://www.w3schools.com/colors/colors_names.asp); although formats with alpha values are recognized, using alpha values less than 100 % (or 1) will currently lead to a color mismatch. 2020.2 and earlier versions of the app require colors to be specified in hex.
 
 ## Setting the app theme
 

--- a/docs/integrations/theming.md
+++ b/docs/integrations/theming.md
@@ -7,6 +7,10 @@ id: 'theming'
 
 ![Android](/assets/android.svg) &nbsp; Android<br /><br />
 Colors should be specified in hex format (e.g. `#0099ff`) and defining element colors through variable names is not supported.
+- `app-header-background-color` for the status- and navigation bar background color ![Android](/assets/android.svg)
+
+![Android](/assets/android.svg) &nbsp; Android <span class="beta">BETA</span><br /><br />
+Colors should be specified in hex format (e.g. `#0099ff`) and defining element colors through variable names is not supported.
 - `primary-background-color` for the navigation bar background color ![Android](/assets/android.svg)
 - `app-header-background-color` for the status bar background color ![Android](/assets/android.svg)
 


### PR DESCRIPTION
The android app uses `app-header-background-color` for its status bar coloring. See: [Ref](https://github.com/home-assistant/android/blob/672e49b6fbd48baff466f0a0ba7dfb3292768602/app/src/main/java/io/homeassistant/companion/android/webview/WebViewActivity.kt#L558)

And will soon be using `primary-background-color` for its navigation bar coloring. See: https://github.com/home-assistant/android/pull/1939