### PR TITLE
Mention lock as supported domain

### DIFF
--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -9,6 +9,7 @@ Home Assistant has started to offer a beta version of the Wear OS app in the Goo
 
 * `input_boolean`
 * `light`
+* `lock`
 * `scene`
 * `script`
 * `switch`


### PR DESCRIPTION
Now that https://github.com/home-assistant/android/pull/1959 is merged we should update the docs :)