### PR TITLE
Remove android beta flags for 2021.12 release

### DIFF
--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -249,7 +249,7 @@ This sensor can impact battery life, particularly if used wih Transmit Power set
 Settings are available to change the UUID, Major and Minor masks. These can be used to change the overall identifier, as well as to allow groups, e.g. family phone devices can have particular Major value which can be whitelisted in apps like roomassistant. These settings are validated: UUID should be the [standard format](https://en.wikipedia.org/wiki/Universally_unique_identifier), Major and Minor need to be within 0 and 65535. 
 There are also settings to alter:
 *   the Transmit power (between Ultra Low, Low, Medium and High)
-*   <span class="beta">BETA</span> the Advertise mode (between Low Power (1Hz), Balanced (3Hz) and Low latency (10Hz))
+*   the Advertise mode (between Low Power (1Hz), Balanced (3Hz) and Low latency (10Hz))
 *   whether to allow this sensor to be turned on when the Enable all sensors toggle is activated (by default this is set to false, to prevent this sensor draining battery unnecessarily)
 
 A Transmit setting toggle will start or stop the BLE transmissions - this setting is also toggled via the notification command that can turn the services on and off. 

--- a/docs/integrations/android-quick-settings.md
+++ b/docs/integrations/android-quick-settings.md
@@ -9,6 +9,4 @@ The Android app offers support for quick settings [tiles](https://developer.andr
 
 The app currently offers 12 tiles for users to setup. Each tile must have a label set and can optionally have a sublabel set. A custom icon can also be used to help differentiate between the tiles. After a label and entity ID have been selected you will be able to update the tile data. Once you have updated your tile data you will be able to edit your devices quick settings menu and then you can drag the Home Assistant icon from the list of tiles into the active section. Once a tile has been added the label and icon will update and the icon will remain in an inactive state. When you select a tile that has proper data set you will see the icon momentarily light up as we execute the service call. Upon success the tile will go back to an inactive state, if there is a failure the tile not be selectable and a toast error message will be shown. If you drag a tile that was not setup yet then the tile will be unavailable preventing action.
 
-<span class="beta">BETA</span><br />
-
 The following domains support the `toggle` service call: cover, fan, humidifier, input_boolean, light, media_player, remote, siren, switch

--- a/docs/integrations/android-webview.md
+++ b/docs/integrations/android-webview.md
@@ -32,7 +32,8 @@ The ![Android](/assets/android.svg) Android app has the ability to launch the [q
 
 ## Keep screen On
 The ![Android](/assets/android.svg) Android app has the ability to keep screen on while webview activity is active by enabling corresponding setting in Companion App Configuration. This lets your device’s screen stay on indefinitely and ignore the Android built-in Sleep settings.
-&nbsp;<span class="beta">BETA</span> This feature may also be controlled by Notification command, [see details](https://companion.home-assistant.io/docs/notifications/notification-commands#screen-on).
+
+This feature may also be controlled by Notification command, [see details](https://companion.home-assistant.io/docs/notifications/notification-commands#screen-on).
 
 ## Autoplay Video
-The ![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span> Android app has the ability to autoplay videos when you load the more info panel. Some devices may already do this by default but others may require this setting by enabling it in Companion App Configuration. Enabling this setting may increase data usage unexpectedly, proceed with caution.
+The ![Android](/assets/android.svg) Android app has the ability to autoplay videos when you load the more info panel. Some devices may already do this by default but others may require this setting by enabling it in Companion App Configuration. Enabling this setting may increase data usage unexpectedly, proceed with caution.

--- a/docs/integrations/theming.md
+++ b/docs/integrations/theming.md
@@ -7,10 +7,6 @@ id: 'theming'
 
 ![Android](/assets/android.svg) &nbsp; Android<br /><br />
 Colors should be specified in hex format (e.g. `#0099ff`) and defining element colors through variable names is not supported.
-- `app-header-background-color` for the status- and navigation bar background color ![Android](/assets/android.svg)
-
-![Android](/assets/android.svg) &nbsp; Android <span class="beta">BETA</span><br /><br />
-Colors should be specified in hex format (e.g. `#0099ff`) and defining element colors through variable names is not supported.
 - `primary-background-color` for the navigation bar background color ![Android](/assets/android.svg)
 - `app-header-background-color` for the status bar background color ![Android](/assets/android.svg)
 

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -554,7 +554,7 @@ On Android you have the option for making a notification only alert once on the 
 ```
 
 ### Notification Status Bar Icon
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+![Android](/assets/android.svg)<br />
 
 On Android you also have the option of changing the notification status bar icon to any icon on [Material Design](https://materialdesignicons.com/). By default the Home Assistant icon will appear. The expected format is the same in Home Assistant `mdi:cellphone`. If you provide an invalid icon name then no icon will be shown. Requires Android 6+.
 

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -344,7 +344,7 @@ automation:
 
 On Android you can turn on the screen using a notification by simply sending `message: command_screen_on`. This will not remove or disable any lock screens you have setup on the device. The reason behind this is the risk associated with the app being unable to set the device policy back (app crash) or if the device requires the policy to be setup again after being removed. All of which is out of the app's control. You may want to adjust the screen timeout setting on your device to control when the screen will turn back off.
 
-&nbsp;<span class="beta">BETA</span> Also you can optionally add `title: keep_screen_on` to enable [Keep screen On](https://companion.home-assistant.io/docs/integrations/android-webview#keep-screen-on) feature in the Companion App section within [Configuration](https://my.home-assistant.io/redirect/config/). The screen will remain on only if the webview activity is currently active, otherwise it will turn back off. Notification with `title` having another value will reset this setting to default Disabled state.
+Also you can optionally add `title: keep_screen_on` to enable [Keep screen On](https://companion.home-assistant.io/docs/integrations/android-webview#keep-screen-on) feature in the Companion App section within [Configuration](https://my.home-assistant.io/redirect/config/). The screen will remain on only if the webview activity is currently active, otherwise it will turn back off. Notification with `title` having another value will reset this setting to default Disabled state.
 
 ```yaml
 automation:


### PR DESCRIPTION
Getting ready for a new release so getting the docs side PR ready.

Blog post PR: https://github.com/home-assistant/home-assistant.io/pull/20774