### PR TITLE
Add a page for documenting Quest specific features

### DIFF
--- a/docs/oculus-quest/oculus-quest.md
+++ b/docs/oculus-quest/oculus-quest.md
@@ -12,8 +12,13 @@ Home Assistant has started to offer the [minimal flavor](/core/android-flavors.m
 </a>
 <br /><br />
 
-The app features many of the sensors offered by the main version as the Quest runs Android. Check out the Manage Sensors screen in settings to see what sensors are currently supported. To learn about each Android sensor and how sensors work in general make sure to check the [sensors](/core/sensors.md#android-sensors) documentation. If you are looking for a sensor to determine if you are currently using the headset then consider enabling the [interactive sensor](/core/sensors.md#interactive-sensor).
 
+| Model | Supported? |
+| ----- | --------- |
+| Oculus Quest | Yes |
+| Oculus Quest 2 | Yes |
+
+The app features many of the sensors offered by the main version as the Quest runs Android. Check out the Manage Sensors screen in settings to see what sensors are currently supported. To learn about each Android sensor and how sensors work in general make sure to check the [sensors](/core/sensors.md#android-sensors) documentation. If you are looking for a sensor to determine if you are currently using the headset then consider enabling the [interactive sensor](/core/sensors.md#interactive-sensor).
 
 Not all features of the Android app will work on the Oculus Quest as it runs a heavily modified fork of Android. There are no google services, no widgets, no shortcuts and no standard notifications.
 

--- a/docs/oculus-quest/oculus-quest.md
+++ b/docs/oculus-quest/oculus-quest.md
@@ -1,0 +1,20 @@
+---
+title: "Overview"
+id: "oculus-quest"
+---
+
+![Android](/assets/android.svg)<br />
+
+Home Assistant has started to offer the [minimal flavor](/core/android-flavors.md) of the Android app for the Oculus Quest. The app can be found in [SideQuest](https://www.sidequestvr.com), the alternative App Store for the Oculus Quest.
+
+<a href="https://sidequestvr.com/app/6427/home-assistant" style={{ display: 'inline-block', width: '200px' }}>
+    <img class="download-badge" width="175" src="https://sidequestvr.com/assets/images/branding/Get-it-on-SIDEQUEST.png" alt="Download on SideQuest" />
+</a>
+<br /><br />
+
+The app features many of the sensors offered by the main version as the Quest runs Android. Check out the Manage Sensors screen in settings to see what sensors are currently supported. To learn about each Android sensor and how sensors work in general make sure to check the [sensors](/core/sensors.md#android-sensors) documentation. If you are looking for a sensor to determine if you are currently using the headset then consider enabling the [interactive sensor](/core/sensors.md#interactive-sensor).
+
+
+Not all features of the Android app will work on the Oculus Quest as it runs a heavily modified fork of Android. There are no google services, no widgets, no shortcuts and no standard notifications.
+
+On this page we will be covering specific features and sensors built for the Oculus Quest as they are ready, stay tuned for more updates!

--- a/sidebars.js
+++ b/sidebars.js
@@ -53,6 +53,9 @@ module.exports = {
       'apple-watch/watch-actions',
       'apple-watch/complications'
     ],
+    'Oculus Quest': [
+      'oculus-quest/oculus-quest'
+    ],
     'Wear OS': [
       'wear-os/wear-os'
     ],

--- a/src/pages/download.js
+++ b/src/pages/download.js
@@ -20,6 +20,9 @@ function Hello() {
             <a href='https://play.google.com/store/apps/details?id=io.homeassistant.companion.android&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'>
               <img width="200" alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png' />
             </a>
+            <a href="https://sidequestvr.com/app/6427/home-assistant" style={{ display: 'inline-block', width: '200px' }}>
+              <img class="download-badge" width="175" src="https://sidequestvr.com/assets/images/branding/Get-it-on-SIDEQUEST.png" alt="Download on SideQuest" />
+            </a>
           </div>
         </div>
       </header>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -25,6 +25,9 @@ const features = [
           <b><a href='/docs/apple-watch'>Apple Watch</a></b>
           {' '}Actions and complications all from your Watch app.
           <br />
+          <b><a href='/docs/oculus-quest/oculus-quest'>Oculus Quest</a></b>
+          {' '}Get data from your Quest into Home Assistant.
+          <br />
           <b><a href='/docs/wear-os'>Wear OS</a></b>
           {' '}Control your home from your Wear OS device <span class="beta">BETA</span>
           <br />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -48,6 +48,10 @@ const features = [
         <a href="https://apps.apple.com/us/app/home-assistant/id1099568401?itsct=apps_box_badge&amp;itscg=30200" style={{ display: 'inline-block', width: '200px' }}>
           <img class="download-badge" width="175" src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83&amp;releaseDate=1492214400&h=3ef4307fa479838e52fe9bd8bd17913b" alt="Download on the App Store" />
         </a>
+        <br />
+        <a href="https://sidequestvr.com/app/6427/home-assistant" style={{ display: 'inline-block', width: '200px' }}>
+          <img class="download-badge" width="175" src="https://sidequestvr.com/assets/images/branding/Get-it-on-SIDEQUEST.png" alt="Download on SideQuest" />
+        </a>
 
         <h2>Source Code</h2>
         <ul>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -25,7 +25,7 @@ const features = [
           <b><a href='/docs/apple-watch'>Apple Watch</a></b>
           {' '}Actions and complications all from your Watch app.
           <br />
-          <b><a href='/docs/oculus-quest/oculus-quest'>Oculus Quest</a></b>
+          <b><a href='/docs/oculus-quest'>Oculus Quest</a></b>
           {' '}Get data from your Quest into Home Assistant.
           <br />
           <b><a href='/docs/wear-os'>Wear OS</a></b>


### PR DESCRIPTION
As we just had the blog post done we should probably have a page ready to document Quest specific features and also to mention where to get the app and how it works.

Not sure if we should also put the link to the app on the home page?