### PR TITLE
Correct Description of Android Geolocate sensor

### DIFF
--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -92,7 +92,7 @@ All sensors update during a periodic 15-minute interval and they will also updat
 | `sensor.current_time_zone` | [See Below](#current-time-zone-sensor) | The current time zone the device is in. |
 | `sensor.current_version` | None | The current installed version of the application. |
 | `sensor.do_not_disturb` | None | The state of do not disturb on the device. |
-| `sensor.geocoded_location` | [See Below](#geocoded-location-sensor) | Calculated address based on GPS data. |
+| `sensor.geocoded_location` | [See Below](#geocoded-location-sensor) | Calculated address based on mobile phone cell towers and WiFi nodes that the mobile client can detect. |
 | `binary_sensor.high_accuracy_mode` | None | The state of high accuracy mode on the device. |
 | [Keyguard Sensors](#keyguard-sensors) | None | Sensors that represent various states about the device being locked or secured. |
 | [Mobile Data Sensors](#mobile-data-sensors) | None | Several different sensors around the state of mobile data. |


### PR DESCRIPTION
Acccording to this Google doc (https://developers.google.com/maps/documentation/geolocation/overview):
"The Geolocation API returns a location and accuracy radius based on information about cell towers and WiFi nodes that the mobile client can detect."

That matches the experience I see in what is reported with the HA Companion App installed on my Android phone. The reported data seems a lot less accurate than the GPS location I get on the same phone (using a GPS app)

iPhone: No idea. I do not have one.