### PR TITLE
Sidequest height on narrow screens

### DIFF
--- a/src/pages/download.js
+++ b/src/pages/download.js
@@ -20,8 +20,8 @@ function Hello() {
             <a href='https://play.google.com/store/apps/details?id=io.homeassistant.companion.android&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1&pcampaignid=pcampaignidMKT-Other-global-all-co-prtnr-py-PartBadge-Mar2515-1'>
               <img width="200" alt='Get it on Google Play' src='https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png' />
             </a>
-            <a href="https://sidequestvr.com/app/6427/home-assistant" style={{ display: 'inline-block', width: '200px' }}>
-              <img class="download-badge" width="175" src="https://sidequestvr.com/assets/images/branding/Get-it-on-SIDEQUEST.png" alt="Download on SideQuest" />
+            <a href="https://sidequestvr.com/app/6427/home-assistant">
+              <img width="175" src="https://sidequestvr.com/assets/images/branding/Get-it-on-SIDEQUEST.png" alt="Download on SideQuest" />
             </a>
           </div>
         </div>


### PR DESCRIPTION
Ensures the Sidequest badge height on download is consistent with other stores on narrow screens

### Before
![image](https://user-images.githubusercontent.com/12411302/148660073-22938f24-cde5-4b34-a8b3-45d632c2a20d.png)

### After
![image](https://user-images.githubusercontent.com/12411302/148660093-d5fba7a6-9c94-4e33-8d9d-e931c4e50303.png)
