### PR TITLE
Add notes about websocket persistent notification

### DIFF
--- a/docs/notifications/local.md
+++ b/docs/notifications/local.md
@@ -24,7 +24,7 @@ Local Push requires HA core-2021.6 or later in combination with a supported plat
 
 ![macOS](/assets/macOS.svg) will always maintain a Local Push connection as long as the app is running and has no additional battery impact.
 
-![Android](/assets/android.svg) will maintain a Local Push connection as specified by your configuration. Depending on your setting this may have adverse affects on battery life. If you are using the minimal flavor you will want to keep this setting as "Always" and consider granting the app background access to make the connection more reliable.
+![Android](/assets/android.svg) will maintain a Local Push connection as specified by your configuration. In order to keep this connection the app will need to create a persistent notification, you will be able to minimize the notification channel for `Websocket` on your device to hide it. Depending on your setting this may have adverse affects on battery life. If you are using the minimal flavor you will want to keep this setting as "Always" and consider granting the app background access to make the connection more reliable.
 
 ## Rate limits
 


### PR DESCRIPTION
Briefly mention the purpose of the persistent notification and that a user can hide it if they wish.