### PR TITLE
Mention support for cover/fan domains in Wear OS documentation

### DIFF
--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -11,6 +11,8 @@ Home Assistant has started to offer a beta version of the Wear OS app in the Goo
 
 The following list of domains are currently supported to toggle/execute once you log in and select them:
 
+* `cover`
+* `fan`
 * `input_boolean`
 * `light`
 * `lock`


### PR DESCRIPTION
Documentation PR for home-assistant/android#2215