### PR TITLE
Add button, input_button to Wear OS supported domains

### DIFF
--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -11,9 +11,11 @@ Home Assistant has started to offer a beta version of the Wear OS app in the Goo
 
 The following list of domains are currently supported to toggle/execute once you log in and select them:
 
+* `button`
 * `cover`
 * `fan`
 * `input_boolean`
+* `input_button`
 * `light`
 * `lock`
 * `scene`


### PR DESCRIPTION
Documentation PR for home-assistant/android#2229