### PR TITLE
Update NFC/QR automation trigger example

### DIFF
--- a/docs/integrations/universal-links.md
+++ b/docs/integrations/universal-links.md
@@ -20,16 +20,14 @@ A Home Assistant NFC tag or QR code contains a URL that will trigger the tag sca
 - ![iOS](/assets/iOS.svg)bringing your device near an NFC tag or scanning a QR code will show a notification which, when tapped, will launch the app and fire an event.
 - ![Android](/assets/android.svg) On Android, bringing your device near a Home Assistant NFC tag or scanning a QR code will fire an event.
 
-The event which fires is the same on both iOS and Android: `tag_scanned`. Example Automation:
+The event which fires is the same on both iOS and Android: `tag_scanned`. For example, in automations, you can use the [tag trigger](https://www.home-assistant.io/docs/automation/trigger/#tag-trigger) to handle these events:
 
 ```yaml
 # for https://www.home-assistant.io/tag/50A3C7C8-1FE7-4BE8-8DC9-06E07D41B63D
 automation:
 - alias: Unlock the Door
   trigger:
-    platform: event
-    event_type: tag_scanned
-    event_data:
+    - platform: tag
       tag_id: 50A3C7C8-1FE7-4BE8-8DC9-06E07D41B63D
   action:
     # ...


### PR DESCRIPTION
Update the example YAML code for the NFC tag/QR code event triggered automation example to use the tag trigger instead of the 'raw' event. Also links to the documentation for the trigger for more advanced examples.

It looks like the iOS app already displays a similar example using the tag platform in the app. For Android, the example will be adjusted to also use the tag platform as part of a larger PR: home-assistant/android#2441