### PR TITLE
Fix Android logo not being rendered

### DIFF
--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -465,8 +465,7 @@ automation:
 
 ## Persistent
 
-<span class='beta'>BETA</span>
-![Android](/assets/android.svg)
+![Android](/assets/android.svg) <span class='beta'>BETA</span><br />
 
 On Android you can toggle the persistent connection mode using a notification by sending `message: command_persistent_connection` and passing `data -> persistent: (always, home_wifi, screen_on, never)`
 


### PR DESCRIPTION
Currently, ```Persistent``` renders like this:
![image](https://user-images.githubusercontent.com/17254809/169521177-9c0ae758-1fae-41f4-a2ee-4e92bf4c0606.png)

So I copied the code from ```Launch App``` which renders correctly:
![image](https://user-images.githubusercontent.com/17254809/169521431-cc654a89-ac9a-4621-a2bb-4541e31cce91.png)

