### PR TITLE
Remove beta labels for stable Android 2022.6.0 release

### DIFF
--- a/docs/core/location.md
+++ b/docs/core/location.md
@@ -169,7 +169,7 @@ You can define a Bluetooth and/or a zone constraint to restrict the use of the h
 :::info
 If you use both constraints (Bluetooth, Zone), then only one constraint must apply to enable the high accuracy mode by default.
 
-You can enable the combination of both constraints by enabling the according option. See [Combination](/docs/core/location#combination-of-zones-constraint-and-bluetooth-constraint) <span class='beta'>BETA</span>
+You can enable the combination of both constraints by enabling the according option. See [Combination](/docs/core/location#combination-of-zones-constraint-and-bluetooth-constraint).
 :::
 
 #### Bluetooth constraint
@@ -212,7 +212,7 @@ Leaving home zone:
 
 - Exiting `zone.home` -> High accuracy mode **disabled**
 
-###### Combination of Zones constraint and Bluetooth constraint <span class='beta'>BETA</span>
+###### Combination of Zones constraint and Bluetooth constraint
 
 It is possible to combine in two ways. First and default option is a simple or combination which is used, when the according switch is turned off. As mentioned in the info box above, only one constraint must apply to enable high accuracy mode.
 
@@ -229,4 +229,4 @@ The high accuracy mode can be also enabled/disable by a notification command. [S
 
 The state of high accuracy mode can be viewed by enabling the [sensor](sensors.md#high-accuracy-mode).
 
-<span class='beta'>BETA</span> The update interval for high accuracy mode can also be viewed by enabling the [sensor](sensors.md#high-accuracy-mode).
+The update interval for high accuracy mode can also be viewed by enabling the [sensor](sensors.md#high-accuracy-mode).

--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -104,7 +104,7 @@ You can change the frequency of sensor updates by navigating to Companion App in
 | `sensor.do_not_disturb` | None | The state of do not disturb on the device. |
 | `sensor.geocoded_location` | [See Below](#geocoded-location-sensor) | Calculated address based on GPS data. |
 | `binary_sensor.high_accuracy_mode` | None | The state of high accuracy mode on the device. |
-| `sensor.high_accuracy_update_interval` | None | The update interval for high accuracy mode on the device. <span class='beta'>BETA</span> |
+| `sensor.high_accuracy_update_interval` | None | The update interval for high accuracy mode on the device. |
 | [Keyguard Sensors](#keyguard-sensors) | None | Sensors that represent various states about the device being locked or secured. |
 | [Mobile Data Sensors](#mobile-data-sensors) | None | Several different sensors around the state of mobile data. |
 | [Notification Sensors](#notification-sensors) | See Below | Details about the notifications on the device. |
@@ -226,7 +226,7 @@ These sensors use the [AudioManager API](https://developer.android.com/reference
 | `is_music_active` | Boolean value if the device is actively playing music, this sensor will update during the normal interval. |
 | `is_speakerphone_on` | Boolean value if the device speakerphone is enabled, Android 10+ will update as this value changes. |
 | `ringer_mode` | The ringer mode on the device, possible values are `normal`, `vibriate` or `silent`. This sensor will update as soon as the ringer mode changes. |
-| `volume_level_*` | The current device volume level for the given volume attributes: `alarm`, `call`, `music`, `ring`. These sensors will update during the normal interval. `accessibility`, `dtmf`, `notification` and `system` are available in the <span class='beta'>BETA</span> |
+| `volume_level_*` | The current device volume level for the given volume attributes: `accessibility`, `alarm`, `call`, `dtmf`, `music`, `notification`, `ring`, `system`. These sensors will update during the normal interval. |
 
 
 ## Battery Sensors
@@ -321,7 +321,7 @@ For Android several different types of connection sensors are available and they
 | `link_speed` | The current link speed of the device to the connected network |
 | `signal_strength` | The signal strength of the device to the WiFi network |
 | `wifi_state` | Whether or not WiFi is turned on for the device |
-| `transport_type` | The transport type for the current network connection. <span class='beta'>BETA</span> |
+| `transport_type` | The transport type for the current network connection. |
 
 ![Android](/assets/android.svg) The `bssid` sensor offers settings to let you rename the current mac address to help avoid the need for templates and secret usage in automations and the front end. This is generally useful if you have multiple access points and want an easy way to differentiate between them. These settings are turned off by default. These sensors require either [Background Location](https://developer.android.com/reference/android/Manifest.permission#ACCESS_BACKGROUND_LOCATION) or [Fine Location](https://developer.android.com/reference/android/Manifest.permission#ACCESS_FINE_LOCATION) permissions, depending on what version of Android you run.
 
@@ -394,7 +394,7 @@ Geocoding is handled directly by iOS's [MapKit](https://developer.apple.com/docu
 ![Android](/assets/android.svg) This sensors state will reflect if the device has [high accuracy mode](location.md#high-accuracy-mode) currently enabled or not. This sensor will update as soon as the state of high accuracy mode changes, the sensor will not appear until high accuracy mode is enabled for the first time.
 
 ## High Accuracy Update Interval
-![Android](/assets/android.svg) <span class='beta'>BETA</span> This sensors state will reflect the update interval for the device in seconds for [high accuracy mode](location.md#high-accuracy-mode). This sensor will update as soon as the value changes either manaully or by the [notification command](../notifications/commands.md#high-accuracy-mode).
+![Android](/assets/android.svg) This sensors state will reflect the update interval for the device in seconds for [high accuracy mode](location.md#high-accuracy-mode). This sensor will update as soon as the value changes either manaully or by the [notification command](../notifications/commands.md#high-accuracy-mode).
 
 ## Interactive Sensor
 ![Android](/assets/android.svg) This sensors state will reflect if the device is in an interactive state. This is typically when the screen comes on and off but may vary from device to device. This sensor will update as soon state changes are detected, data is provided by [PowerManager](https://developer.android.com/reference/android/os/PowerManager.html).

--- a/docs/integrations/android-widgets.md
+++ b/docs/integrations/android-widgets.md
@@ -73,8 +73,6 @@ You may also use HTML to format the text displayed such as adding a new line (`<
 
 ## Theming
 
-<span class="beta">BETA</span>
-
 Most widgets allow selecting a theme to use. The available themes depend on your device and the specific widget. Possible options are:
 
  - *Dynamic color*: uses the colors from your device and wallpaper to make the widget fit in with your home screen and device. This theme is only available on supported devices running Android 12 or newer.

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -437,8 +437,6 @@ automation:
 
 ### Notification Sensitivity / Lock Screen Visibility
 
-<span class='beta'>BETA</span>
-
 You can change how much of a notification is visible on the lock screen by using the `visibility` option. Possible values for this property are:
 
  - `public`: always show all notification content

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -28,7 +28,7 @@ The Companion apps offer a lot of different notification options. In place of po
 | `command_media` | Control media playing on the device, [see below](#media) for how it works and whats required. |
 | `command_ringer_mode` | Control the ringer mode on the device, [see below](#ringer-mode) for how it works and whats required. |
 | `command_screen_on` | Turn on the device screen. |
-| `command_persistent_connection` | <span class='beta'>BETA</span> Toggle persistent connection mode. [see below](#persistent) for the available modes. |
+| `command_persistent_connection` | Toggle persistent connection mode, [see below](#persistent) for the available modes. |
 | `command_update_sensors` | Updates all enabled sensors, if the state changed since the last update. |
 | `command_volume_level` | Control the volume for all available audio streams, [see below](#volume-level) for how it works and whats required. |
 | `command_webview` | Open the app to the homepage or any dashboard or view, [see below](#webview) for how. |
@@ -321,8 +321,6 @@ automation:
           title: "turn_off"
 ```
 
-<span class='beta'>BETA</span><br />
-
 You can also adjust the update interval of high accuracy mode by following the example below. You must send a valid value that cannot be less than `5`. Anything else will result in the notification posting to the device. After performing this command high accuracy mode will restart which can take a few seconds to complete.
 
 ```yaml
@@ -341,7 +339,7 @@ automation:
 
 ## Launch App
 
-![Android](/assets/android.svg) <span class='beta'>BETA</span><br />
+![Android](/assets/android.svg)
 
 If you would like to simply just launch an application you can use `message: command_launch_app` to launch any application installed on your device. You must send the package name you wish to open using the `package_name` parameter, if not set then you will see the notification post as normal. If the application is not installed on the device then the user will be directed to the Google Play Store to install the application. This command requires the Draw Over Other Apps permission, the first time you send this command you will be directed to granting this special permission to the Home Assistant application.
 
@@ -465,7 +463,7 @@ automation:
 
 ## Persistent
 
-![Android](/assets/android.svg) <span class='beta'>BETA</span><br />
+![Android](/assets/android.svg)
 
 On Android you can toggle the persistent connection mode using a notification by sending `message: command_persistent_connection` and passing `data -> persistent: (always, home_wifi, screen_on, never)`
 
@@ -496,12 +494,12 @@ On Android you can control the devices volume level by sending `message: command
 | `channel` | Description |
 | ------- | ----------- |
 | `alarm_stream` | Set the volume level for the alarm stream. |
-| `call_stream` | Set the volume level for the voice call stream. <span class='beta'>BETA</span> |
-| `dtmf_stream` | Set the volume level for DTMF tones. <span class='beta'>BETA</span> |
+| `call_stream` | Set the volume level for the voice call stream. |
+| `dtmf_stream` | Set the volume level for DTMF tones. |
 | `music_stream` | Set the volume level for the music stream. |
 | `notification_stream` | Set the volume level for the notification stream. |
 | `ring_stream` | Set the volume level for the ring stream. |
-| `system_stream` | Set the volume level for the system stream. <span class='beta'>BETA</span> |
+| `system_stream` | Set the volume level for the system stream. |
 | Anything else | The notification will post as a normal notification and the command will not process. |
 <br />
 

--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -3,9 +3,11 @@ title: "Overview"
 id: "wear-os"
 ---
 
-![Android](/assets/android.svg) &nbsp;<span class="beta">BETA</span><br />
+![Android](/assets/android.svg)
 
-Home Assistant has started to offer a beta version of the Wear OS app in the Google Play Store. Support at this moment is very minimal. You must be a beta user of the phone app to [participate in the beta](https://play.google.com/apps/testing/io.homeassistant.companion.android) for the watch app.
+You can access Home Assistant directly from your Wear OS watch, even when not connected to your phone using a WiFi or cellular connection on the watch or when using an iPhone. 
+
+The app does not support all Home Assistant features. Keep an eye out on this page as the app is enhanced with new features!
 
 ## Home Screen
 
@@ -53,9 +55,3 @@ Right now, two tiles are supported:
 ## Sensors
 
 The Wear OS app will have [sensors](../core/sensors.md). To start with, it will only report the [battery sensors](../core/sensors.md#battery-sensors). Its important to note that sensor updates require the app to post a notification to the device in order to prevent it from being killed by the OS. You can go to into Wear device settings and turn off the SensorWorker Notification channel to stop these notifications from buzzing on your wrist.
-
-## Beta
-
-You can sign up for the beta [here](https://play.google.com/apps/testing/io.homeassistant.companion.android). Once installed you will be directed to adding your server and logging in.
-
-Keep an eye out on this page as the application is enhanced with new features!

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -29,7 +29,7 @@ const features = [
           {' '}Get data from your Quest into Home Assistant.
           <br />
           <b><a href='/docs/wear-os'>Wear OS</a></b>
-          {' '}Control your home from your Wear OS device <span class="beta">BETA</span>
+          {' '}Control your home from your Wear OS device.
           <br />
           <b><a href='/docs/troubleshooting/faqs'>Troubleshooting</a></b>
           {' '}If you need some help, this is a great place to start.


### PR DESCRIPTION
There's [a new stable Android release](https://github.com/home-assistant/android/releases/tag/2022.6.0) and it is available on the Play Store, so the beta labels should be removed for Android.

This PR also updates the Wear OS description because it is no longer exclusively available using the beta.