### PR TITLE
Update Android WebView quick bar gesture support

### DIFF
--- a/docs/integrations/android-webview.md
+++ b/docs/integrations/android-webview.md
@@ -44,4 +44,4 @@ The ![Android](/assets/android.svg) Android app has the ability to enable [chrom
 
 The ![Android](/assets/android.svg) Android app has the ability to launch the [quick bar](https://www.home-assistant.io/docs/tools/quick-bar/) by detecting a 3 finger swipe down gesture. Initially the entity filter will be shown, you can switch to the command palette by typing `>` at the start of the input. The quick bar can only be launched when inside the webview after you have logged in.
 
-<span class="beta">BETA</span> This gesture is no longer supported.
+This gesture is only supported on Home Assistant core 2022.6 or earlier.

--- a/docs/integrations/android-webview.md
+++ b/docs/integrations/android-webview.md
@@ -43,3 +43,5 @@ The ![Android](/assets/android.svg) Android app has the ability to enable [chrom
 ## Swipe Gestures
 
 The ![Android](/assets/android.svg) Android app has the ability to launch the [quick bar](https://www.home-assistant.io/docs/tools/quick-bar/) by detecting a 3 finger swipe down gesture. Initially the entity filter will be shown, you can switch to the command palette by typing `>` at the start of the input. The quick bar can only be launched when inside the webview after you have logged in.
+
+<span class="beta">BETA</span> This gesture is no longer supported.


### PR DESCRIPTION
The quick bar gesture in the Android app no longer works due to frontend changes, update docs to reflect this.

(See discussion in home-assistant/android#2690, the PR initially completely removed support)