### PR TITLE
Improve Android client certificate docs

### DIFF
--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -58,4 +58,5 @@ Once you have set up your first server, you can add additional Home Assistant in
 ![Android](/assets/android.svg)<span class="beta">BETA</span>
 
 If your Home Assistant requires TLS Client Authentication (because it is behind a reverse proxy configured to perform TLS Client Authentication), the app will ask for a certificate. If no matching certificate is installed or supplied, you might see an error or a blank screen depending on your setup.
+
 Please refer to your device and Android version documentation to install the certificate. Make sure to install the certificate as a "VPN & app user certificate". An example for Pixel phones is available here: [Add & remove certificates](https://support.google.com/pixelphone/answer/2844832?hl=en). 

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -57,5 +57,5 @@ Once you have set up your first server, you can add additional Home Assistant in
 
 ![Android](/assets/android.svg)<span class="beta">BETA</span>
 
-If your Home Assistant requires TLS Client Authentication (because it is behind a reverse proxy configured to perform TLS Client Authentication), the app will ask for a certificate.
-Please refer to your device and Android version documentation to install the certificate, an example for Pixel phones is available here [Add & remove certificates](https://support.google.com/pixelphone/answer/2844832?hl=en).
+If your Home Assistant requires TLS Client Authentication (because it is behind a reverse proxy configured to perform TLS Client Authentication), the app will ask for a certificate. If no matching certificate is installed or supplied, you might see an error or a blank screen depending on your setup.
+Please refer to your device and Android version documentation to install the certificate. Make sure to install the certificate as a "VPN & app user certificate". An example for Pixel phones is available here: [Add & remove certificates](https://support.google.com/pixelphone/answer/2844832?hl=en). 


### PR DESCRIPTION
While working on bugfixes for the Android app yesterday, I noticed that setting up client certificate authentication is a bit more involved than the documentation suggests. This PR tweaks the text to clarify some potential pitfalls.

 - Specify that the certificate should be added as a "VPN & app user certificate"; the linked example suggests importing it as a Wi-Fi certificate, in which case it will not show up.
 - Note that nothing might happen if a certificate hasn't been installed before trying to access an instance that uses it.