### PR TITLE
Add note about Android template widget rate limits

### DIFF
--- a/docs/integrations/android-widgets.md
+++ b/docs/integrations/android-widgets.md
@@ -61,11 +61,11 @@ This widget will make the service call when it is tapped. The user will see a gr
 
 ### Template
 
-This widget will display any text that you wish to show in a widget using [Home Assistants templating feature](https://www.home-assistant.io/docs/configuration/templating/). This is an advanced feature but allows the user to display a wide variety of data. The templated will be updated instantly on relevant states changes. When editing the widget, the template will be shown below the text field so you can preview what it would look like.
+This widget will display any text that you wish to show in a widget using [Home Assistants templating feature](https://www.home-assistant.io/docs/configuration/templating/). This is an advanced feature but allows the user to display a wide variety of data. The template will be updated instantly on relevant states changes. When editing the widget, the template will be shown below the text field so you can preview what it would look like.
 
 You may also use HTML to format the text displayed such as adding a new line (`<br>`), making something bold (`<b>`) or large (`<big>`) or changing the color (`<font color='#03a9f4'>`).
 
-<span class='beta'>BETA</span> If the template in the widget isn't updating instantly, you're most likely hitting [rate limits](https://www.home-assistant.io/integrations/template/#rate-limiting-updates). Try optimizing your template to get faster updates, or tap on the widget to update it manually. You can also use the preview in [Developer Tools > Template](https://my.home-assistant.io/redirect/developer_template/) to test your template updates.
+<span class='beta'>BETA</span> If the template in the widget isn't updating instantly, you're most likely hitting [rate limits](https://www.home-assistant.io/integrations/template/#rate-limiting-updates). Try optimizing your template to get faster updates, or tap on the widget to update it manually. You can also use the preview in [`Developer Tools > Template`](https://my.home-assistant.io/redirect/developer_template/) to test your template updates.
 
 1.  Long press on any open space in the home screen
 2.  Scroll down to Home Assistant in the widget list

--- a/docs/integrations/android-widgets.md
+++ b/docs/integrations/android-widgets.md
@@ -61,9 +61,11 @@ This widget will make the service call when it is tapped. The user will see a gr
 
 ### Template
 
-This widget will display any text that you wish to show in a widget using [Home Assistants templating feature](https://www.home-assistant.io/docs/configuration/templating/). This is an advanced feature but allows the user to display a wide variety of data. The widget will render the templates live below the text field so you can preview what it would look like. 
+This widget will display any text that you wish to show in a widget using [Home Assistants templating feature](https://www.home-assistant.io/docs/configuration/templating/). This is an advanced feature but allows the user to display a wide variety of data. The templated will be updated instantly on relevant states changes. When editing the widget, the template will be shown below the text field so you can preview what it would look like.
 
 You may also use HTML to format the text displayed such as adding a new line (`<br>`), making something bold (`<b>`) or large (`<big>`) or changing the color (`<font color='#03a9f4'>`).
+
+<span class='beta'>BETA</span> If the template in the widget isn't updating instantly, you're most likely hitting [rate limits](https://www.home-assistant.io/integrations/template/#rate-limiting-updates). Try optimizing your template to get faster updates, or tap on the widget to update it manually. You can also use the preview in [Developer Tools > Template](https://my.home-assistant.io/redirect/developer_template/) to test your template updates.
 
 1.  Long press on any open space in the home screen
 2.  Scroll down to Home Assistant in the widget list


### PR DESCRIPTION
Documentation PR for home-assistant/android#2801 based on a review comment.

Labeled with BETA because the app currently updates the template on any state change, so no rate limiting is applied (and it can be very inefficient).