### PR TITLE
Update docs for Android August release

### DIFF
--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -240,7 +240,7 @@ The battery sensors listed below describe the state of the battery for a few dif
 | --------- | --------- |
 | `battery_health` | The health of the battery |
 | `battery_level` | The percentage of battery remaining |
-| `battery_power` | The current wattage on the device <span class="beta">BETA</span> |
+| `battery_power` | The current wattage on the device |
 | `battery_state` | The state of charging on the device |
 | `battery_temperature` | The current battery temperature |
 | `charger_type` | The type of charger being used on the device |
@@ -322,7 +322,7 @@ For Android several different types of connection sensors are available and they
 | `link_speed` | The current link speed of the device to the connected network |
 | `signal_strength` | The signal strength of the device to the WiFi network |
 | `wifi_state` | Whether or not WiFi is turned on for the device |
-| `transport_type` | The transport type for the current network connection. <span class='beta'>BETA</span> An attribute will reflect if the current network is metered. |
+| `transport_type` | The transport type for the current network connection. An attribute will reflect if the current network is metered. |
 
 ![Android](/assets/android.svg) The `bssid` sensor offers settings to let you rename the current mac address to help avoid the need for templates and secret usage in automations and the front end. This is generally useful if you have multiple access points and want an easy way to differentiate between them. These settings are turned off by default. These sensors require either [Background Location](https://developer.android.com/reference/android/Manifest.permission#ACCESS_BACKGROUND_LOCATION) or [Fine Location](https://developer.android.com/reference/android/Manifest.permission#ACCESS_FINE_LOCATION) permissions, depending on what version of Android you run.
 
@@ -449,9 +449,9 @@ Below you can find some details that can be given with some notifications.
 | `is_ongoing` | If the notification is persistent on the device. |
 | `package` | The package that posted the notification. |
 | `post_time` | The time the notification was posted on the device. |
-| `channel_id` | The ID of the channel the notification posted to. This attribute is only available on Android 8+. <span class="beta">BETA</span> |
-| `group_id` | The ID of the group the notification posted to. <span class="beta">BETA</span> |
-| `category` | The category that the notification defined. <span class="beta">BETA</span> |
+| `channel_id` | The ID of the channel the notification posted to. This attribute is only available on Android 8+. |
+| `group_id` | The ID of the group the notification posted to. |
+| `category` | The category that the notification defined. |
 
 
 ### Media Session Sensor

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -55,7 +55,7 @@ Once you have set up your first server, you can add additional Home Assistant in
 
 ## TLS Client Authentication
 
-![Android](/assets/android.svg)<span class="beta">BETA</span> excluding Wear OS
+![Android](/assets/android.svg)
 
 If your Home Assistant requires TLS Client Authentication (because it is behind a reverse proxy configured to perform TLS Client Authentication), the app will ask for a certificate. If no matching certificate is installed or supplied, you might see an error or a blank screen depending on your setup.
 

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -55,7 +55,7 @@ Once you have set up your first server, you can add additional Home Assistant in
 
 ## TLS Client Authentication
 
-![Android](/assets/android.svg)
+![Android](/assets/android.svg) excluding Wear OS
 
 If your Home Assistant requires TLS Client Authentication (because it is behind a reverse proxy configured to perform TLS Client Authentication), the app will ask for a certificate. If no matching certificate is installed or supplied, you might see an error or a blank screen depending on your setup.
 

--- a/docs/integrations/android-device-controls.md
+++ b/docs/integrations/android-device-controls.md
@@ -12,7 +12,7 @@ The following domains are supported:
 
 *  `automation` On/Off
 *  `button` Press
-*  `camera` Snapshot image (only supported on Android 12 or newer) <span class="beta">BETA</span>
+*  `camera` Snapshot image (only supported on Android 12 or newer)
 *  `climate` Temperature slider
 *  `cover` Open/Close
 *  `fan` On/Off, speed slider

--- a/docs/integrations/android-quick-settings.md
+++ b/docs/integrations/android-quick-settings.md
@@ -18,7 +18,7 @@ The following domains are supported:
 *  `input_boolean` Toggle
 *  `input_button` Press
 *  `light` Toggle
-*  `lock` Lock/Unlock <span class='beta'>BETA</span>
+*  `lock` Lock/Unlock
 *  `media_player` Toggle
 *  `remote` Toggle
 *  `siren` Toggle

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -537,7 +537,7 @@ automation:
             tts_text: Motion has been detected
 ```
 
-Please see the below table for new parameters to use after updating the android app to 2022.8+:
+Please see the below table for new parameters to use after updating the Android app to 2022.8+:
 
 | Old Parameter | New Parameter |
 |--------|--------|

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -462,7 +462,7 @@ automation:
 
 ### Text To Speech Notifications
 
-Instead of posting a notification on the device you can instead get your device to speak the notification. This notification works different than the others. You will set `message: TTS` and the actual text to speak would be in the `title`. Current support is limited to the current Text To Speech locale set on the device. If there is an error processing the message you will see a toast message appear on the device. Check to make sure that the [Google Text To Speech](https://play.google.com/store/apps/details?id=com.google.android.tts) engine is up to date and set as the default, in case you run into any issues.
+Instead of posting a notification on the device you can instead get your device to speak the notification. This notification works different than the others. You will set `message: TTS` and the actual text to speak would be in the `tts_text`. Current support is limited to the current Text To Speech locale set on the device. If there is an error processing the message you will see a toast message appear on the device. Check to make sure that the [Google Text To Speech](https://play.google.com/store/apps/details?id=com.google.android.tts) engine is up to date and set as the default, in case you run into any issues.
 
 ```yaml
 automation:
@@ -473,10 +473,11 @@ automation:
       - service: notify.mobile_app_<your_device_id_here>
         data:
           message: "TTS"
-          title: "Motion has been detected"
+          data:
+            tts_text: "Motion has been detected"
 ```
 
-By default Text To Speech notifications use the music stream so they will bypass the ringer mode on the device as long as the device's volume is not set to 0. You have the option of using `channel: alarm_stream` to have your notification spoken regardless of music volume.
+By default Text To Speech notifications use the music stream so they will bypass the ringer mode on the device as long as the device's volume is not set to 0. You have the option of using `media_stream: alarm_stream` to have your notification spoken regardless of music volume.
 
 ```yaml
 automation:
@@ -487,12 +488,12 @@ automation:
       - service: notify.mobile_app_<your_device_id_here>
         data:
           message: TTS
-          title: "Motion has been detected"
           data:
-            channel: "alarm_stream"
+            tts_text: "Motion has been detected"
+            media_stream: "alarm_stream"
 ```
 
-If you find that your alarm stream volume is too low you can use `channel: alarm_stream_max` which will temporarily set the alarm stream volume to the max level, play the notification and then revert back to the original volume level.
+If you find that your alarm stream volume is too low you can use `media_stream: alarm_stream_max` which will temporarily set the alarm stream volume to the max level, play the notification and then revert back to the original volume level.
 
 ```yaml
 automation:
@@ -503,9 +504,9 @@ automation:
       - service: notify.mobile_app_<your_device_id_here>
         data:
           message: "TTS"
-          title: "Alarm has been triggered"
           data:
-            channel: "alarm_stream_max"
+            tts_text: "Alarm has been triggered"
+            media_stream: "alarm_stream_max"
 ```
 
 You may not want the TTS notification to be spoken in certain situations (e.g. if the Ringer mode is not `normal` or DND is enabled). This can be done by adding a condition in your automation that checks the state of [other sensors](https://companion.home-assistant.io/docs/core/sensors). Few examples are presented below:
@@ -532,29 +533,17 @@ automation:
       - service: notify.mobile_app_<your_device_id_here>
         data:
           message: TTS
-          title: Motion has been detected
+          data:
+            tts_text: Motion has been detected
 ```
 
-If you are a &nbsp;<span class="beta">BETA</span> user please see the below table for new parameters to use:
+Please see the below table for new parameters to use after updating the android app to 2022.8+:
 
 | Old Parameter | New Parameter |
 |--------|--------|
 | `channel` | `media_stream` |
 | `title` | `tts_text` |
 
-```yaml
-automation:
-  - alias: "Notify of Motion TTS alarm"
-    trigger:
-      ...
-    action:
-      - service: notify.mobile_app_<your_device_id_here>
-        data:
-          message: TTS
-          data:
-            media_stream: "alarm_stream"
-            tts_text: "Motion has been detected"
-```
 
 ### Chronometer Notifications
 

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -228,7 +228,7 @@ automation:
           message: "command_broadcast_intent"
           data:
             intent_package_name: "package-name"
-            intent_action: "action
+            intent_action: "action"
 ```
 
 An example of an application that accepts broadcast intents is [Sleep as Android](https://docs.sleep.urbandroid.org/devs/intent_api.html#action-intents-to-control-sleep). To start a sleep tracking event the format would be as follows:

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -90,7 +90,7 @@ automation:
 
 In order to use the Intent Action `android.intent.action.CALL` you will also need to grant the app Phone permissions. If not granted the app will direct you to the app info screen to grant the permissions along with a toast message letting you know the missing permissions.
 
-Please see the below table for new parameters to use after updating the android app to 2022.8+:
+Please see the below table for new parameters to use after updating the Android app to 2022.8+:
 
 | Old Parameter | New Parameter |
 |--------|--------|
@@ -179,7 +179,7 @@ automation:
             ble_uuid: "b4306bba-0e3a-44df-9518-dc74284e8214"
 ```
 
-If you have updated the android app to 2022.8 you must use `command` in place of `title` like the below example:
+If you have updated the Android app to 2022.8 you must use `command` in place of `title`.
 
 ## Bluetooth
 
@@ -202,7 +202,7 @@ automation:
             command: "turn_off"
 ```
 
-If you have updated the android app to 2022.8 you must use `command` in place of `title` like the below example:
+If you have updated the Android app to 2022.8 you must use `command` in place of `title`.
 
 
 ## Broadcast Intent
@@ -316,7 +316,7 @@ automation:
 ```
 
 
-Please see the below table for new parameters to use after updating the android app to 2022.8+:
+Please see the below table for new parameters to use after updating the Android app to 2022.8+:
 
 | Old Parameter | New Parameter |
 |--------|--------|
@@ -356,7 +356,7 @@ automation:
             command: "priority_only"
 ```
 
-If you have updated the android app to 2022.8 you must use `command` in place of `title` like the below example:
+If you have updated the Android app to 2022.8 you must use `command` in place of `title`.
 
 ## High accuracy mode
 
@@ -395,7 +395,7 @@ automation:
             command: "high_accuracy_set_update_interval"
 ```
 
-If you have updated the android app to 2022.8 you must use `command` in place of `title` like the below example:
+If you have updated the Android app to 2022.8 you must use `command` in place of `title`.
 
 ## Launch App
 
@@ -448,7 +448,7 @@ automation:
             media_package_name: "com.spotify.music"
 ```
 
-Please see the below table for new parameters to use after updating the android app to 2022.8+:
+Please see the below table for new parameters to use after updating the Android app to 2022.8+:
 
 | Old Parameter | New Parameter |
 |--------|--------|
@@ -510,7 +510,7 @@ automation:
             command: "vibrate"
 ```
 
-If you have updated the android app to 2022.8 you must use `command` in place of `title` like the below example:
+If you have updated the Android app to 2022.8 you must use `command` in place of `title`.
 
 
 ## Screen On
@@ -619,7 +619,7 @@ automation:
             command: 20
 ```
 
-If you have updated the android app to 2022.8 you must use `command` in place of `title` like the below example:
+Please see the below table for new parameters to use after updating the Android app to 2022.8+:
 
 | Old Parameter | New Parameter |
 |--------|--------|
@@ -648,4 +648,4 @@ automation:
             command: "/lovelace/settings"
 ```
 
-If you have updated the android app to 2022.8 you must use `command` in place of `title` like the below example:
+If you have updated the Android app to 2022.8 you must use `command` in place of `title`.

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -28,7 +28,7 @@ The Companion apps offer a lot of different notification options. In place of po
 | `command_media` | Control media playing on the device, [see below](#media) for how it works and whats required. |
 | `command_ringer_mode` | Control the ringer mode on the device, [see below](#ringer-mode) for how it works and whats required. |
 | `command_screen_on` | Turn on the device screen. |
-| `command_stop_tts` | Stops Text To Speech if it's currently in use. <span class='beta'>BETA</span> |
+| `command_stop_tts` | Stops Text To Speech if it's currently in use. |
 | `command_persistent_connection` | Toggle persistent connection mode, [see below](#persistent) for the available modes. |
 | `command_update_sensors` | Updates all enabled sensors, if the state changed since the last update. |
 | `command_volume_level` | Control the volume for all available audio streams, [see below](#volume-level) for how it works and whats required. |
@@ -43,13 +43,13 @@ The Companion apps offer a lot of different notification options. In place of po
 
 On Android you can send `message: command_activity` to launch any activity. This command requires a specific permission that the app is unable to prompt or auto-accept. Instead by sending the command for the first time the app will launch an activity allowing the user to enable Home Assistant access to the devices Display over other apps Policy. This is required in order for the app to gain control of this setting.
 
-The `tag` parameter will need to be set to the Intent Action string, or the notification will post as normal. If the activity requires a URI then you will need set that as the `title`, otherwise the notification will post as normal. `channel` can be set to the package of where the activity is to be launched, otherwise Android will make a best effort to pick a default. If the package cannot be found then the notification will post as normal. You must know the intending URI (if required), action and package to start the activity. Typically this will be a documented feature if supported by the app.
+The `intent_action` parameter will need to be set to the Intent Action string, or the notification will post as normal. If the activity requires a URI then you will need set that as the `intent_uri`, otherwise the notification will post as normal. `intent_package_name` can be set to the package of where the activity is to be launched, otherwise Android will make a best effort to pick a default. If the package cannot be found then the notification will post as normal. You must know the intending URI (if required), action and package to start the activity. Typically this will be a documented feature if supported by the app.
 
-[Extras](https://developer.android.com/reference/android/content/Intent#putExtra(java.lang.String,%20java.lang.String)) are also supported under the `group` parameter. As there can be any number of extras added to the intent we will need to split each extra by a comma `,`. Then each extra name and value needs to be separated by a colon `:`. Please refer to the example in [Broadcast Intent](#broadcast-intent) to see the proper format.
+[Extras](https://developer.android.com/reference/android/content/Intent#putExtra(java.lang.String,%20java.lang.String)) are also supported under the `intent_extras` parameter. As there can be any number of extras added to the intent we will need to split each extra by a comma `,`. Then each extra name and value needs to be separated by a colon `:`. Please refer to the example in [Broadcast Intent](#broadcast-intent) to see the proper format.
 
-`subject` can also be set to the MIME type if you need to set it. You will need to know the MIME type string if the activity requires it.
+`intent_type` can also be set to the MIME type if you need to set it. You will need to know the MIME type string if the activity requires it.
 
-Some applications also require the class or component to be provided. For these applications you will need to provide the package as the `channel` and the full and complete class name under the `intent_class_name` parameter. You will need to know what class name to provide as each application is different.
+Some applications also require the class or component to be provided. For these applications you will need to provide the package as the `intent_package_name` and the full and complete class name under the `intent_class_name` parameter. You will need to know what class name to provide as each application is different.
 
 The below example follows [Google's documentation](https://developers.google.com/maps/documentation/urls/android-intents#launch-turn-by-turn-navigation) to show you how this feature works by launching Google Maps Navigation.
 
@@ -64,41 +64,13 @@ automation:
       - service: notify.mobile_app_<your_device_id_here>
         data:
           message: "command_activity"
-          title: "google.navigation:q=arbys"
           data:
-            channel: "com.google.android.apps.maps"
-            tag: "android.intent.action.VIEW"
+            intent_package_name: "com.google.android.apps.maps"
+            intent_action: "android.intent.action.VIEW"
+            intent_uri: "google.navigation:q=arbys"
 ```
 
 To continue with the above example you can also launch [search results](https://developer.android.com/guide/components/intents-common#Maps) with the following:
-
-```yaml
-automation:
-  - alias: Search google maps
-    trigger:
-      ...
-    action:
-      - service: notify.mobile_app_<your_device_id_here>
-        data:
-          message: "command_activity"
-          title: "geo:0,0?q=1600+Amphitheatre+Parkway%2C+CA"
-          data:
-            channel: "com.google.android.apps.maps"
-            tag: "android.intent.action.VIEW"
-```
-
-
-In order to use the Intent Action `android.intent.action.CALL` you will also need to grant the app Phone permissions. If not granted the app will direct you to the app info screen to grant the permissions along with a toast message letting you know the missing permissions.
-
-If you are a &nbsp;<span class="beta">BETA</span> user please see the below table for new parameters to use:
-
-| Old Parameter | New Parameter |
-|--------|--------|
-| `channel` | `intent_package_name` |
-| `group` | `intent_extras` |
-| `subject` | `intent_type` |
-| `tag` | `intent_action` |
-| `title` | `intent_uri` |
 
 ```yaml
 automation:
@@ -115,59 +87,27 @@ automation:
             intent_uri: "geo:0,0?q=1600+Amphitheatre+Parkway%2C+CA"
 ```
 
+
+In order to use the Intent Action `android.intent.action.CALL` you will also need to grant the app Phone permissions. If not granted the app will direct you to the app info screen to grant the permissions along with a toast message letting you know the missing permissions.
+
+Please see the below table for new parameters to use after updating the android app to 2022.8+:
+
+| Old Parameter | New Parameter |
+|--------|--------|
+| `channel` | `intent_package_name` |
+| `group` | `intent_extras` |
+| `subject` | `intent_type` |
+| `tag` | `intent_action` |
+| `title` | `intent_uri` |
+
+
 ## BLE Beacon Transmitter
 
 ![Android](/assets/android.svg)
 
-Users can turn the iBeacon transmitter on or off using `message: command_ble_transmitter` with the `title` being either `turn_off` or `turn_on`. If `title` is blank, not set or not one of the above expected values then the notification will post as normal.
+Users can turn the iBeacon transmitter on or off using `message: command_ble_transmitter` with the `command` being either `turn_off` or `turn_on`. If `command` is blank, not set or not one of the above expected values then the notification will post as normal.
 
 Example:
-
-```yaml
-automation:
-  - alias: Turn off BLE transmitter
-    trigger:
-      ...
-    action:
-      - service: notify.mobile_app_<your_device_id_here>
-        data:
-          message: "command_ble_transmitter"
-          title: "turn_off"
-```
-
-You can also adjust the advertise mode and transmit power of the BLE Transmitter. To adjust the Advertise mode you will need to set `title` to `ble_set_advertise_mode` and then set the `ble_advertise` parameter to either `ble_advertise_low_latency`, `ble_advertise_balanced` or `ble_advertise_low_power`
-
-```yaml
-automation:
-  - alias: Change Advertise Mode BLE transmitter
-    trigger:
-      ...
-    action:
-      - service: notify.mobile_app_<your_device_id_here>
-        data:
-          message: "command_ble_transmitter"
-          title: "ble_set_advertise_mode"
-          data:
-            ble_advertise: "ble_advertise_balanced"
-```
-
-To adjust Transmit Power you will need to set `title` to `ble_set_transmit_power` and then set the `ble_transmit` parameter to either `ble_transmit_high`, `ble_transmit_medium`, `ble_transmit_low` or `ble_transmit_ultra_low`
-
-```yaml
-automation:
-  - alias: Change Transmit Power BLE transmitter
-    trigger:
-      ...
-    action:
-      - service: notify.mobile_app_<your_device_id_here>
-        data:
-          message: "command_ble_transmitter"
-          title: "ble_set_transmit_power"
-          data:
-            ble_transmit: "ble_transmit_high"
-```
-
-If you are a &nbsp;<span class="beta">BETA</span> user you must use `command` in place of `title` like the below example:
 
 ```yaml
 automation:
@@ -182,7 +122,38 @@ automation:
             command: "turn_off"
 ```
 
-<span class="beta">BETA</span>
+You can also adjust the advertise mode and transmit power of the BLE Transmitter. To adjust the Advertise mode you will need to set `command` to `ble_set_advertise_mode` and then set the `ble_advertise` parameter to either `ble_advertise_low_latency`, `ble_advertise_balanced` or `ble_advertise_low_power`
+
+```yaml
+automation:
+  - alias: Change Advertise Mode BLE transmitter
+    trigger:
+      ...
+    action:
+      - service: notify.mobile_app_<your_device_id_here>
+        data:
+          message: "command_ble_transmitter"
+          data:
+            command: "ble_set_advertise_mode"
+            ble_advertise: "ble_advertise_balanced"
+```
+
+To adjust Transmit Power you will need to set `command` to `ble_set_transmit_power` and then set the `ble_transmit` parameter to either `ble_transmit_high`, `ble_transmit_medium`, `ble_transmit_low` or `ble_transmit_ultra_low`
+
+```yaml
+automation:
+  - alias: Change Transmit Power BLE transmitter
+    trigger:
+      ...
+    action:
+      - service: notify.mobile_app_<your_device_id_here>
+        data:
+          message: "command_ble_transmitter"
+          data:
+            command: "ble_set_transmit_power"
+            ble_transmit: "ble_transmit_high"
+```
+
 
 Users can also change the reporting UUID, Major and Minor parameters by using the following commands and their respective parameters. You can send any type of string value for the UUID, Major and Minor attributes. If any data is missing the notification will post as normal on the device.
 
@@ -208,27 +179,15 @@ automation:
             ble_uuid: "b4306bba-0e3a-44df-9518-dc74284e8214"
 ```
 
+If you have updated the android app to 2022.8 you must use `command` in place of `title` like the below example:
+
 ## Bluetooth
 
 ![Android](/assets/android.svg)
 
-Users can turn Bluetooth on or off using `message: command_bluetooth` with the `title` being either `turn_off` or `turn_on`. If `title` is blank, not set or not one of the above expected values then the notification will post as normal.
+Users can turn Bluetooth on or off using `message: command_bluetooth` with the `command` being either `turn_off` or `turn_on`. If `command` is blank, not set or not one of the above expected values then the notification will post as normal.
 
 Example:
-
-```yaml
-automation:
-  - alias: Command bluetooth
-    trigger:
-      ...
-    action:
-      - service: notify.mobile_app_<your_device_id_here>
-        data:
-          message: "command_bluetooth"
-          title: "turn_off"
-```
-
-If you are a &nbsp;<span class="beta">BETA</span> user you must use `command` in place of `title` like the below example:
 
 ```yaml
 automation:
@@ -243,13 +202,16 @@ automation:
             command: "turn_off"
 ```
 
+If you have updated the android app to 2022.8 you must use `command` in place of `title` like the below example:
+
+
 ## Broadcast Intent
 
 ![Android](/assets/android.svg)
 
-Using notification commands you are now able to send a broadcast intent to another app in order to control that app based on the intent. Not all apps support intents and if they do they may document it for users to control. You must set `message: command_broadcast_intent` and the `title` must contain the intent action while `channel` must contain the package the intent is for. The package name and action are provided by the app you wish to send the intent to.
+Using notification commands you are now able to send a broadcast intent to another app in order to control that app based on the intent. Not all apps support intents and if they do they may document it for users to control. You must set `message: command_broadcast_intent` and the `intent_action` must contain the intent action while `intent_package_name` must contain the package the intent is for. The package name and action are provided by the app you wish to send the intent to.
 
-Some applications also require the class or component to be provided. For these applications you will need to provide the package as the `channel` and the full and complete class name under the `intent_class_name` parameter. You will need to know what class name to provide as each application is different.
+Some applications also require the class or component to be provided. For these applications you will need to provide the package as the `intent_package_name` and the full and complete class name under the `intent_class_name` parameter. You will need to know what class name to provide as each application is different.
 
 If an invalid format is sent you may either see a notification or a toast message.
 
@@ -264,9 +226,9 @@ automation:
       - service: notify.mobile_app_<your_device_id_here>
         data:
           message: "command_broadcast_intent"
-          title: "action"
           data:
-            channel: "package-name"
+            intent_package_name: "package-name"
+            intent_action: "action
 ```
 
 An example of an application that accepts broadcast intents is [Sleep as Android](https://docs.sleep.urbandroid.org/devs/intent_api.html#action-intents-to-control-sleep). To start a sleep tracking event the format would be as follows:
@@ -280,12 +242,13 @@ automation:
       - service: notify.mobile_app_<your_device_id_here>
         data:
           message: "command_broadcast_intent"
-          title: "com.urbandroid.sleep.alarmclock.START_SLEEP_TRACK"
           data:
-            channel: "com.urbandroid.sleep"
+            intent_package_name: "com.urbandroid.sleep"
+            intent_action: "com.urbandroid.sleep.alarmclock.START_SLEEP_TRACK"
+
 ```
 
-[Extras](https://developer.android.com/reference/android/content/Intent#putExtra(java.lang.String,%20java.lang.String)) are also supported under the `group` parameter. As there can be any number of extras added to the intent we will need to split each extra by a comma `,`. Then each extra name and value needs to be separated by a colon `:`. The below example shows you how to turn on an alarm labeled `work` in the Sleep as Android application. In this example there are 2 extras being added to the intent.
+[Extras](https://developer.android.com/reference/android/content/Intent#putExtra(java.lang.String,%20java.lang.String)) are also supported under the `intent_extras` parameter. As there can be any number of extras added to the intent we will need to split each extra by a comma `,`. Then each extra name and value needs to be separated by a colon `:`. The below example shows you how to turn on an alarm labeled `work` in the Sleep as Android application. In this example there are 2 extras being added to the intent.
 
 ```yaml
 automation:
@@ -296,10 +259,11 @@ automation:
       - service: notify.mobile_app_<your_device_id_here>
         data:
           message: "command_broadcast_intent"
-          title: "com.urbandroid.sleep.alarmclock.ALARM_STATE_CHANGE"
           data:
-            channel: "com.urbandroid.sleep"
-            group: "alarm_label:work,alarm_enabled:false"
+            intent_package_name: "com.urbandroid.sleep"
+            intent_extras: "alarm_label:work,alarm_enabled:false"
+            intent_action: "com.urbandroid.sleep.alarmclock.ALARM_STATE_CHANGE"
+
 ```
 
 Special characters in extras are supported by urlencoding the extra value and appending `:urlencoded` to the end. For example, to send a JSON-formatted extra to Gadgetbridge we can do the following:
@@ -313,10 +277,11 @@ automation:
       - service: notify.mobile_app_<your_device_id_here>
         data:
           message: "command_broadcast_intent"
-          title: "nodomain.freeyourgadget.gadgetbridge.Q_PUSH_CONFIG"
           data:
-            channel: "nodomain.freeyourgadget.gadgetbridge"
-            group: "EXTRA_CONFIG_JSON:%7B%22push%22%3A%7B%22set%22%3A%7B%22widgetCustom0._.config.upper_text%22%3A%22Hi%22%7D%7D%7D:urlencoded"
+            intent_package_name: "nodomain.freeyourgadget.gadgetbridge"
+            intent_extras: "EXTRA_CONFIG_JSON:%7B%22push%22%3A%7B%22set%22%3A%7B%22widgetCustom0._.config.upper_text%22%3A%22Hi%22%7D%7D%7D:urlencoded"
+            intent_action: "nodomain.freeyourgadget.gadgetbridge.Q_PUSH_CONFIG"
+
 ```
 
 Similarly to using urlencoding, you can add specific types to your intent extra. Your values will then be converted according to the type you specified. Make sure the type conversion is possible/meaningful.
@@ -344,14 +309,14 @@ automation:
       - service: notify.mobile_app_<your_device_id_here>
         data:
           message: "command_broadcast_intent"
-          title: "sample.intent.SAMPLE"
           data:
-            channel: "sample"
-            group: "EXTRA:1;2;3:ArrayList<Integer>"
+            intent_package_name: "sample"
+            intent_extras: "EXTRA:1;2;3:ArrayList<Integer>"
+            intent_action: "sample.intent.SAMPLE"
 ```
 
 
-If you are a &nbsp;<span class="beta">BETA</span> user please see the below table for new parameters to use:
+Please see the below table for new parameters to use after updating the android app to 2022.8+:
 
 | Old Parameter | New Parameter |
 |--------|--------|
@@ -359,32 +324,17 @@ If you are a &nbsp;<span class="beta">BETA</span> user please see the below tabl
 | `group` | `intent_extras` |
 | `title` | `intent_action` |
 
-```yaml
-automation:
-  - alias: Send broadcast intent with extras
-    trigger:
-      ...
-    action:
-      - service: notify.mobile_app_<your_device_id_here>
-        data:
-          message: "command_broadcast_intent"
-          data:
-            intent_action: "com.urbandroid.sleep.alarmclock.ALARM_STATE_CHANGE"
-            intent_package_name: "com.urbandroid.sleep"
-            intent_extras: "alarm_label:work,alarm_enabled:false"
-```
-
 ## Do Not Disturb
 
 ![Android](/assets/android.svg) &nbsp;Android 6+ only
 
 On Android you can send `message: command_dnd` that you can use to control the state of Do Not Disturb on the device. This command requires a specific permission that the app is unable to prompt or auto-accept. Instead by sending the command for the first time the app will launch an activity allowing the user to enable Home Assistant access to the devices Notification Policy. This is required in order for the app to gain control of this setting.
 
-In addition to sending the `message` you must also provide the state of Do Not Disturb that you wish to set as the `title`, see the table below for what is accepted. If the `title` does not match one of the listed commands then the notification will post as normal and the command will not process. This command is only available for users on Android 6+, users on lower versions will see the notification just like any other.
+In addition to sending the `message` you must also provide the state of Do Not Disturb that you wish to set as the `command`, see the table below for what is accepted. If the `command` does not match one of the listed commands then the notification will post as normal and the command will not process. This command is only available for users on Android 6+, users on lower versions will see the notification just like any other.
 <br />
 
 
-| `title` | Description |
+| `command` | Description |
 | ------- | ----------- |
 | `alarms_only` | Alarms only interruption filter - all notifications except those in the alarm category are suppressed. Some audio streams are muted. |
 | `off` | Normal interruption filter - no notifications are suppressed. |
@@ -402,61 +352,19 @@ automation:
       - service: notify.mobile_app_<your_device_id_here>
         data:
           message: "command_dnd"
-          title: "priority_only"
-```
-
-If you are a &nbsp;<span class="beta">BETA</span> user you must use `command` in place of `title` like the below example:
-
-```yaml
-automation:
-  - alias: Command do not disturb
-    trigger:
-      ...
-    action:
-      - service: notify.mobile_app_<your_device_id_here>
-        data:
-          message: "command_dnd"
           data:
             command: "priority_only"
 ```
+
+If you have updated the android app to 2022.8 you must use `command` in place of `title` like the below example:
 
 ## High accuracy mode
 
 ![Android](/assets/android.svg)
 
-Users can turn the high accuracy mode of the background location sensor on or off using `message: command_high_accuracy_mode` with the `title` being either `turn_off` or `turn_on`. If `title` is blank, not set or not one of the above expected values then the notification will post as normal.
+Users can turn the high accuracy mode of the background location sensor on or off using `message: command_high_accuracy_mode` with the `command` being either `turn_off` or `turn_on`. If `command` is blank, not set or not one of the above expected values then the notification will post as normal.
 
 Example:
-
-```yaml
-automation:
-  - alias: Turn off high accuracy mode
-    trigger:
-      ...
-    action:
-      - service: notify.mobile_app_<your_device_id_here>
-        data:
-          message: "command_high_accuracy_mode"
-          title: "turn_off"
-```
-
-You can also adjust the update interval of high accuracy mode by following the example below. You must send a valid value that cannot be less than `5`. Anything else will result in the notification posting to the device. After performing this command high accuracy mode will restart which can take a few seconds to complete.
-
-```yaml
-automation:
-  - alias: Set high accuracy update interval
-    trigger:
-      ...
-    action:
-      - service: notify.mobile_app_<your_device_id_here>
-        data:
-          message: "command_high_accuracy_mode"
-          title: "high_accuracy_set_update_interval"
-          data:
-            high_accuracy_update_interval: 60
-```
-
-If you are a &nbsp;<span class="beta">BETA</span> user you must use `command` in place of `title` like the below example:
 
 ```yaml
 automation:
@@ -470,6 +378,24 @@ automation:
           data:
             command: "turn_off"
 ```
+
+You can also adjust the update interval of high accuracy mode by following the example below. You must send a valid value that cannot be less than `5`. Anything else will result in the notification posting to the device. After performing this command high accuracy mode will restart which can take a few seconds to complete.
+
+```yaml
+automation:
+  - alias: Set high accuracy update interval
+    trigger:
+      ...
+    action:
+      - service: notify.mobile_app_<your_device_id_here>
+        data:
+          message: "command_high_accuracy_mode"
+          data:
+            high_accuracy_update_interval: 60
+            command: "high_accuracy_set_update_interval"
+```
+
+If you have updated the android app to 2022.8 you must use `command` in place of `title` like the below example:
 
 ## Launch App
 
@@ -494,9 +420,9 @@ automation:
 
 ![Android](/assets/android.svg)
 
-Users are able to control any active media session on their devices. You must set `message: command_media` and the `title` must be one from the list below. The `channel` must be set to the package name you wish to control. The notification will post as normal if one of the required fields is left blank, has incorrect data or a media session is not active.
+Users are able to control any active media session on their devices. You must set `message: command_media` and the `media_command` must be one from the list below. The `media_package_name` must be set to the package name you wish to control. The notification will post as normal if one of the required fields is left blank, has incorrect data or a media session is not active.
 
-List of accepted `title` media commands:
+List of accepted `media_command` media commands:
 *  `fast_forward`
 *  `next`
 *  `pause`
@@ -517,31 +443,18 @@ automation:
       - service: notify.mobile_app_<your_device_id_here>
         data:
           message: "command_media"
-          title: "pause"
           data:
-            channel: "com.spotify.music"
+            media_command: "pause"
+            media_package_name: "com.spotify.music"
 ```
 
-If you are a &nbsp;<span class="beta">BETA</span> user please see the below table for new parameters to use:
+Please see the below table for new parameters to use after updating the android app to 2022.8+:
 
 | Old Parameter | New Parameter |
 |--------|--------|
 | `channel` | `media_package_name` |
 | `title` | `media_command` |
 
-```yaml
-automation:
-  - alias: Pause spotify
-    trigger:
-      ...
-    action:
-      - service: notify.mobile_app_<your_device_id_here>
-        data:
-          message: "command_media"
-          data:
-            media_command: "pause"
-            media_package_name: "com.spotify.music"
-```
 
 ## Request Location Updates
 
@@ -574,9 +487,9 @@ While it is possible to create an automation in Home Assistant to call this serv
 
 ![Android](/assets/android.svg)
 
-On Android you can control the devices ringer mode by sending `message: command_ringer_mode` with an appropriate `title` as outlined in the table below. Certain devices will need to grant a special permission that will appear upon the first command received if the permission was not already granted. This is the same permission as [Do Not Disturb](#do-not-disturb) up above. If the device has Do Not Disturb enabled then setting to `normal` or `vibrate` will turn it off. If the device does not have Do Not Disturb enabled then `silent` will turn it on.<br />
+On Android you can control the devices ringer mode by sending `message: command_ringer_mode` with an appropriate `command` as outlined in the table below. Certain devices will need to grant a special permission that will appear upon the first command received if the permission was not already granted. This is the same permission as [Do Not Disturb](#do-not-disturb) up above. If the device has Do Not Disturb enabled then setting to `normal` or `vibrate` will turn it off. If the device does not have Do Not Disturb enabled then `silent` will turn it on.<br />
 
-| `title` | Description |
+| `command` | Description |
 | ------- | ----------- |
 | `normal` | Set the device to normal ringer mode, will turn off Do Not Disturb if enabled and supported. |
 | `silent` | Set the device to silent ringer mode, will turn on Do Not Disturb if disabled and supported. |
@@ -593,23 +506,12 @@ automation:
       - service: notify.mobile_app_<your_device_id_here>
         data:
           message: "command_ringer_mode"
-          title: "vibrate"
-```
-
-If you are a &nbsp;<span class="beta">BETA</span> user you must use `command` in place of `title` like the below example:
-
-```yaml
-automation:
-  - alias: Command ringer mode
-    trigger:
-      ...
-    action:
-      - service: notify.mobile_app_<your_device_id_here>
-        data:
-          message: "command_ringer_mode"
           data:
             command: "vibrate"
 ```
+
+If you have updated the android app to 2022.8 you must use `command` in place of `title` like the below example:
+
 
 ## Screen On
 
@@ -617,7 +519,7 @@ automation:
 
 On Android you can turn on the screen using a notification by simply sending `message: command_screen_on`. This will not remove or disable any lock screens you have setup on the device. The reason behind this is the risk associated with the app being unable to set the device policy back (app crash) or if the device requires the policy to be setup again after being removed. All of which is out of the app's control. You may want to adjust the screen timeout setting on your device to control when the screen will turn back off.
 
-Also you can optionally add `title: keep_screen_on` to enable [Keep screen On](https://companion.home-assistant.io/docs/integrations/android-webview#keep-screen-on) feature in the Companion App section within [Configuration](https://my.home-assistant.io/redirect/config/). The screen will remain on only if the webview activity is currently active, otherwise it will turn back off. Notification with `title` having another value will reset this setting to default Disabled state.
+Also you can optionally add `command: keep_screen_on` to enable [Keep screen On](https://companion.home-assistant.io/docs/integrations/android-webview#keep-screen-on) feature in the Companion App section within [Configuration](https://my.home-assistant.io/redirect/config/). The screen will remain on only if the webview activity is currently active, otherwise it will turn back off. Notification with `command` having another value will reset this setting to default Disabled state.
 
 ```yaml
 automation:
@@ -628,12 +530,13 @@ automation:
       - service: notify.mobile_app_<your_device_id_here>
         data:
           message: "command_screen_on"
-          title: "keep_screen_on"
+          data:
+            command: "keep_screen_on"
 ```
 
 ## Stop TTS
 
-![Android](/assets/android.svg) <span class='beta'>BETA</span>
+![Android](/assets/android.svg)
 
 If you wish to stop the device from completing its Text to Speech notification you can stop it by sending the command `message: command_stop_tts`.
 
@@ -687,9 +590,9 @@ automation:
 
 ![Android](/assets/android.svg)
 
-On Android you can control the devices volume level by sending `message: command_volume_level` with an appropriate `title` that must be a number. If `title` is larger than the maximum level then the maximum level will be used or if `title` is less than `0` then we will default to `0`, anything else will result in the notification posting to the device. `channel` is also required as outlined in the table below. Certain devices will need to grant a special permission that will appear upon the first command received if the permission was not already granted. This is the same permission as [Do Not Disturb](#do-not-disturb) up above. Changing the volume level will have a direct impact on Do Not Disturb and Ringer Modes, behavior will vary from device to device.<br />
+On Android you can control the devices volume level by sending `message: command_volume_level` with an appropriate `command` that must be a number. If `command` is larger than the maximum level then the maximum level will be used or if `command` is less than `0` then we will default to `0`, anything else will result in the notification posting to the device. `media_stream` is also required as outlined in the table below. Certain devices will need to grant a special permission that will appear upon the first command received if the permission was not already granted. This is the same permission as [Do Not Disturb](#do-not-disturb) up above. Changing the volume level will have a direct impact on Do Not Disturb and Ringer Modes, behavior will vary from device to device.<br />
 
-| `channel` | Description |
+| `media_stream` | Description |
 | ------- | ----------- |
 | `alarm_stream` | Set the volume level for the alarm stream. |
 | `call_stream` | Set the volume level for the voice call stream. |
@@ -712,51 +615,25 @@ automation:
           message: "command_volume_level"
           title: 20
           data:
-            channel: "music_stream"
+            media_stream: "music_stream"
+            command: 20
 ```
 
-If you are a &nbsp;<span class="beta">BETA</span> user please see the below table for new parameters to use:
+If you have updated the android app to 2022.8 you must use `command` in place of `title` like the below example:
 
 | Old Parameter | New Parameter |
 |--------|--------|
 | `channel` | `media_stream` |
 | `title` | `command` |
 
-```yaml
-automation:
-  - alias: Command volume level
-    trigger:
-      ...
-    action:
-      - service: notify.mobile_app_<your_device_id_here>
-        data:
-          message: "command_volume_level"
-          data:
-            media_stream: "music_stream"
-            command: 20
-```
 
 ## Webview
 
 ![Android](/assets/android.svg)
 
-If you want to just open the Companion app to any page or even the homepage you will want to send `message: command_webview`. If you wish to navigate to a specific [view](https://www.home-assistant.io/lovelace/views/) or [dashboard](https://www.home-assistant.io/lovelace/dashboards/) you will want to use `title` to specify the [`path`](https://www.home-assistant.io/lovelace/views/#path) (example: `/lovelace/settings`). You can also open the More Info panel for any entity by using the following format for `title`: `entityId:sun.sun` just replace `sun.sun` with the entity you wish to open. If `title` is not provided the user will be directed to the homepage. The first time you send this command you will be taken to a permission screen to grant the app access to display over other apps policy. This permission is necessary for the feature to work in the background and we cannot prompt the user to grant it.
+If you want to just open the Companion app to any page or even the homepage you will want to send `message: command_webview`. If you wish to navigate to a specific [view](https://www.home-assistant.io/lovelace/views/) or [dashboard](https://www.home-assistant.io/lovelace/dashboards/) you will want to use `command` to specify the [`path`](https://www.home-assistant.io/lovelace/views/#path) (example: `/lovelace/settings`). You can also open the More Info panel for any entity by using the following format for `command`: `entityId:sun.sun` just replace `sun.sun` with the entity you wish to open. If `command` is not provided the user will be directed to the homepage. The first time you send this command you will be taken to a permission screen to grant the app access to display over other apps policy. This permission is necessary for the feature to work in the background and we cannot prompt the user to grant it.
 
 Example:
-
-```yaml
-automation:
-  - alias: Open android webview
-    trigger:
-      ...
-    action:
-      - service: notify.mobile_app_<your_device_id_here>
-        data:
-          message: "command_webview"
-          title: "/lovelace/settings"
-```
-
-If you are a &nbsp;<span class="beta">BETA</span> user you must use `command` in place of `title` like the below example:
 
 ```yaml
 automation:
@@ -770,3 +647,5 @@ automation:
           data:
             command: "/lovelace/settings"
 ```
+
+If you have updated the android app to 2022.8 you must use `command` in place of `title` like the below example:

--- a/docs/notifications/critical.md
+++ b/docs/notifications/critical.md
@@ -71,7 +71,7 @@ automations:
 ```
 
 ### ![Android](/assets/android.svg) Alarm Stream
-You can also force the notification to play from the alarm stream so it will make the device ring even if on vibrate/silent ringer mode. Users on Android 7 and below can still use the `channel` example below as we are just using it to override the default notification behavior for sound. In order to make a notification show up immediately and make a sound regardless of ringer mode follow one of the examples below.
+You can also force the notification to play from the alarm stream so it will make the device ring even if on vibrate/silent ringer mode. Users on Android 7 and below can still use the `media_stream` example below as we are just using it to override the default notification behavior for sound. In order to make a notification show up immediately and make a sound regardless of ringer mode follow one of the examples below.
 
 Using this method to can send a normal notification:
 
@@ -91,8 +91,10 @@ automations:
           data:
             ttl: 0
             priority: high
-            channel: alarm_stream
+            media_stream: alarm_stream
 ```
+
+If you have updated the android app to 2022.8+ then replace the parameter `channel` with `media_stream`
 
 ### ![Android](/assets/android.svg) Text To Speech Alarm Stream
 Or you can use Text To Speech to speak the notification:
@@ -108,36 +110,21 @@ automations:
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          title: "The house is on fire and the cat's stuck in the dryer!"
           message: TTS
           data:
             ttl: 0
             priority: high
-            channel: alarm_stream
+            media_stream: alarm_stream
+            tts_text: "The house is on fire and the cat's stuck in the dryer!"
 ```
 
-If you are a &nbsp;<span class="beta">BETA</span> user please see the below table for new parameters to use:
+Please see the below table for new parameters to use after updating the android app to 2022.8+:
 
 | Old Parameter | New Parameter |
 |--------|--------|
 | `channel` | `media_stream` |
 | `title` | `tts_text` |
 
-```yaml
-automation:
-  - alias: "Fire Detected TTS alarm"
-    trigger:
-      ...
-    action:
-      - service: notify.mobile_app_<your_device_id_here>
-        data:
-          message: TTS
-          data:
-            ttl: 0
-            priority: high
-            media_stream: "alarm_stream"
-            tts_text: "The house is on fire and the cat's stuck in the dryer!"
-```
 
 ### ![Android](/assets/android.svg) Text To Speech Alarm Stream Max Volume
 Alternatively using Text To Speech you can also make the notification speak as loud as it can, and then revert back to the original volume level:
@@ -154,33 +141,17 @@ automations:
     action:
       - service: notify.mobile_app_<your_device_id_here>
         data:
-          title: "The house is on fire and the cat's stuck in the dryer!"
           message: TTS
           data:
             ttl: 0
             priority: high
-            channel: alarm_stream_max
+            media_stream: alarm_stream_max
+            tts_text: "The house is on fire and the cat's stuck in the dryer!"
 ```
 
-If you are a &nbsp;<span class="beta">BETA</span> user please see the below table for new parameters to use:
+Please see the below table for new parameters to use after updating the android app to 2022.8+:
 
 | Old Parameter | New Parameter |
 |--------|--------|
 | `channel` | `media_stream` |
 | `title` | `tts_text` |
-
-```yaml
-automation:
-  - alias: "Fire Detected TTS loud"
-    trigger:
-      ...
-    action:
-      - service: notify.mobile_app_<your_device_id_here>
-        data:
-          message: TTS
-          data:
-            ttl: 0
-            priority: high
-            media_stream: "alarm_stream_max"
-            tts_text: "The house is on fire and the cat's stuck in the dryer!"
-```

--- a/docs/notifications/critical.md
+++ b/docs/notifications/critical.md
@@ -94,7 +94,7 @@ automations:
             media_stream: alarm_stream
 ```
 
-If you have updated the android app to 2022.8+ then replace the parameter `channel` with `media_stream`
+If you have updated the Android app to 2022.8+ then replace the parameter `channel` with `media_stream`.
 
 ### ![Android](/assets/android.svg) Text To Speech Alarm Stream
 Or you can use Text To Speech to speak the notification:
@@ -118,7 +118,7 @@ automations:
             tts_text: "The house is on fire and the cat's stuck in the dryer!"
 ```
 
-Please see the below table for new parameters to use after updating the android app to 2022.8+:
+Please see the below table for new parameters to use after updating the Android app to 2022.8+:
 
 | Old Parameter | New Parameter |
 |--------|--------|
@@ -149,7 +149,7 @@ automations:
             tts_text: "The house is on fire and the cat's stuck in the dryer!"
 ```
 
-Please see the below table for new parameters to use after updating the android app to 2022.8+:
+Please see the below table for new parameters to use after updating the Android app to 2022.8+:
 
 | Old Parameter | New Parameter |
 |--------|--------|

--- a/docs/notifications/received.md
+++ b/docs/notifications/received.md
@@ -3,7 +3,7 @@ title: "Notification Received"
 id: "notification-received"
 ---
 
-![Android](/assets/android.svg) <span class='beta'>BETA</span>
+![Android](/assets/android.svg)
 
 Anytime a notification is received on the Android device an event will be sent to Home Assistant. All notification data will be present in the event data for the event type `mobile_app_notification_received`.
 

--- a/docs/troubleshooting/networking.md
+++ b/docs/troubleshooting/networking.md
@@ -70,7 +70,7 @@ Note: If you don't use the NGINX Home Assistant add-on but instead roll your own
 
 ### TLS Client Authentication
 
-![Android](/assets/android.svg)<span class="beta">BETA</span>
+![Android](/assets/android.svg)
 
 If your Home Assistant requires TLS Client Authentication (because it is behind a reverse proxy configured to perform TLS Client Authentication), the app will ask for a certificate.
 Please refer to your device and Android version documentation to install the certificate, an example for Pixel phones is available here [Add & remove certificates](https://support.google.com/pixelphone/answer/2844832?hl=en).

--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -54,8 +54,6 @@ Right now, two tiles are supported:
 
 ### Styling the template tile
 
-<span class="beta">BETA</span>
-
 You may use HTML to format the text displayed. The following tags are currently supported:
 
 * Adding a new line: `<br>`
@@ -65,8 +63,6 @@ You may use HTML to format the text displayed. The following tags are currently 
 * Using headers: `<h1>title</h1>`, `<h2>subtitle</h2>`, etc.
 
 ## Complications
-
-<span class="beta">BETA</span>
 
 An entity state complication can be displayed on your watchface. The complication is of the 'short text' type and will display the current state of the selected entity. Depending on the watch face it will also show the entity name and icon. When you add an entity to a watch face, you can select the entity to display. To change the selected entity, just change the complication and select the entity state complication again.
 


### PR DESCRIPTION
Please only merge this once the play store release is live!

- Removes all beta tags for the android release
- Updates all notification commands to the new format along with keeping the old parameter table and mentioning that things changed in 2022.8