### PR TITLE
Fix rendering links for beta note on template widget

### DIFF
--- a/docs/integrations/android-widgets.md
+++ b/docs/integrations/android-widgets.md
@@ -65,7 +65,9 @@ This widget will display any text that you wish to show in a widget using [Home 
 
 You may also use HTML to format the text displayed such as adding a new line (`<br>`), making something bold (`<b>`) or large (`<big>`) or changing the color (`<font color='#03a9f4'>`).
 
-<span class='beta'>BETA</span> If the template in the widget isn't updating instantly, you're most likely hitting [rate limits](https://www.home-assistant.io/integrations/template/#rate-limiting-updates). Try optimizing your template to get faster updates, or tap on the widget to update it manually. You can also use the preview in [`Developer Tools > Template`](https://my.home-assistant.io/redirect/developer_template/) to test your template updates.
+<span class='beta'>BETA</span>
+
+If the template in the widget isn't updating instantly, you're most likely hitting [rate limits](https://www.home-assistant.io/integrations/template/#rate-limiting-updates). Try optimizing your template to get faster updates, or tap on the widget to update it manually. You can also use the preview in [`Developer Tools > Template`](https://my.home-assistant.io/redirect/developer_template/) to test your template updates.
 
 1.  Long press on any open space in the home screen
 2.  Scroll down to Home Assistant in the widget list


### PR DESCRIPTION
Noticed the links weren't rendering properly and looks like it needed some extra spacing :)

![image](https://user-images.githubusercontent.com/1634145/187342504-dff261e1-91b4-4838-bc61-1f58eca80a83.png)
