### PR TITLE
Make Android quick settings tile docs less technical

### DIFF
--- a/docs/integrations/android-quick-settings.md
+++ b/docs/integrations/android-quick-settings.md
@@ -5,9 +5,11 @@ id: 'android-quick-settings'
 
 ![Android](/assets/android.svg)<br />
 
-The Android app offers support for quick settings [tiles](https://developer.android.com/reference/android/service/quicksettings/TileService) allowing the user to quickly execute a script/scene, press (input) buttons or toggle supported domains from the notification pull down menu. Users are able to fully customize the appearance of these tile and can reorganize them as they see fit. This feature is available on devices running Android 7.0+.
+The Android app offers support for quick settings [tiles](https://developer.android.com/reference/android/service/quicksettings/TileService) allowing you to quickly execute a script/scene, press (input) buttons or toggle supported domains from the notification pull down menu. You can fully customize the appearance of these tile and can reorganize them as you see fit. This feature is available on devices running Android 7.0+.
 
-The app currently offers 12 tiles for users to setup. Each tile must have a label set and can optionally have a sublabel set. A custom icon can also be used to help differentiate between the tiles. After a label and entity ID have been selected you will be able to update the tile data. Once you have updated your tile data you will be able to edit your devices quick settings menu and then you can drag the Home Assistant icon from the list of tiles into the active section. Once a tile has been added the label and icon will update and the icon will remain in an inactive state. When you select a tile that has proper data set you will see the icon momentarily light up as we execute the service call. Upon success the tile will go back to an inactive state, if there is a failure the tile not be selectable and a toast error message will be shown. If you drag a tile that was not setup yet then the tile will be unavailable preventing action.
+The app currently offers 12 tiles to setup. Each tile must have a label set and on Android 10 or newer can optionally have a sublabel set. A custom icon can also be used to help differentiate between the tiles. After a label and entity have been selected you will be able to update the tile data. Once updated, the tile is ready to be used: edit your device's quick settings panel and drag the Home Assistant tile from the list of tiles into the active section.
+
+Once a tile has been added, the state, label and icon will update to reflect the entity's state and tile settings. When you select a tile you will see the tile momentarily light up as the app calls the server. If successfull the tile will go back to show the entity's state, if there is a failure the tile change to a disabled state and an error message will be shown.
 
 The following domains are supported: 
 

--- a/docs/integrations/android-quick-settings.md
+++ b/docs/integrations/android-quick-settings.md
@@ -9,7 +9,7 @@ The Android app offers support for quick settings [tiles](https://developer.andr
 
 The app currently offers 12 tiles to setup. Each tile must have a label set and on Android 10 or newer can optionally have a sublabel set. A custom icon can also be used to help differentiate between the tiles. After a label and entity have been selected you will be able to update the tile data. Once updated, the tile is ready to be used: edit your device's quick settings panel and drag the Home Assistant tile from the list of tiles into the active section.
 
-Once a tile has been added, the state, label and icon will update to reflect the entity's state and tile settings. When you select a tile you will see the tile momentarily light up as the app calls the server. If successfull the tile will go back to show the entity's state, if there is a failure the tile change to a disabled state and an error message will be shown.
+Once a tile has been added, the state, label and icon will update to reflect the entity's state and tile settings. When you select a tile you will see the tile momentarily light up as the app calls the server. If successfull the tile will go back to show the entity's state, if there is a failure the tile changes to a disabled state and an error message will be shown.
 
 The following domains are supported: 
 


### PR DESCRIPTION
Documentation PR for home-assistant/android#2860

I've taken this oppurtunity to also slightly rewrite the page to always direct text to the reader ('you') instead of a mix of reader/user, and make it less technical overall. 