### PR TITLE
Update URL handler page to account for Android support

### DIFF
--- a/docs/integrations/url-handler.md
+++ b/docs/integrations/url-handler.md
@@ -3,12 +3,14 @@ title: "URL Handler"
 id: 'url-handler'
 ---
 
-![iOS](/assets/iOS.svg)<br />
-Home Assistant for iOS supports opening from other apps via URL.
+Home Assistant supports opening from other apps via URL.
 
 Query parameters are passed as a dictionary in the call.
 
+:::info
+![iOS](/assets/iOS.svg)<br />
 If multiple servers are connected to an iOS or mac app, you will be prompted to select a server when handling a `navigate` link, `call_service`, or `fire_event`  links will be handled using the first server in the list.
+:::
 
 ## Navigate
 This allows you to update the frontend page location via a deeplink. This requires version 2021.3 or later.
@@ -16,12 +18,15 @@ This allows you to update the frontend page location via a deeplink. This requir
 For example: if you had a dashboard at `/lovelace/webcams` you can use `homeassistant://navigate/lovelace/webcams` to launch the app there.
 
 ## Call service
+![iOS](/assets/iOS.svg)<br />
 Example: `homeassistant://call_service/device_tracker.see?entity_id=device_tracker.entity`
 
 ## Fire event
+![iOS](/assets/iOS.svg)<br />
 You can create an [event trigger](https://www.home-assistant.io/docs/automation/trigger/#event-trigger) and fire the event.
 
 Example: `homeassistant://fire_event/custom_event?entity_id=MY_CUSTOM_EVENT`
 
 ## Send one shot location
+![iOS](/assets/iOS.svg)<br />
 Example: `homeassistant://send_location/`

--- a/docs/integrations/url-handler.md
+++ b/docs/integrations/url-handler.md
@@ -13,7 +13,7 @@ If multiple servers are connected to an iOS or mac app, you will be prompted to 
 :::
 
 ## Navigate
-This allows you to update the frontend page location via a deeplink. This requires version 2021.3 or later.
+This allows you to update the frontend page location via a deeplink.
 
 For example: if you had a dashboard at `/lovelace/webcams` you can use `homeassistant://navigate/lovelace/webcams` to launch the app there.
 


### PR DESCRIPTION
Looks like we forgot to update this page to no longer be iOS specific after the android app added support for the navigation feature which I believe was done as part of the NFC addition.

Made some adjustments to make it more clear which parts are iOS only 