### PR TITLE
Fix incorrect statement on feature requests

### DIFF
--- a/docs/troubleshooting/more-help.md
+++ b/docs/troubleshooting/more-help.md
@@ -9,8 +9,11 @@ If after reading the docs here you are still having issues, try the following re
 *   Visit the [iOS Discord Channel](https://discordapp.com/channels/330944238910963714/551871772484698112) or [Android Discord Channel](https://discordapp.com/channels/330944238910963714/562408603345092636)
 *   Post on the [iOS forums](https://community.home-assistant.io/c/mobile-apps/ios) or [Android forums](https://community.home-assistant.io/c/mobile-apps/android-companion).
 
-**For bug reports or feature requests**
+**For bug reports**
 *   Please raise an issue on the [iOS GitHub repository](https://github.com/home-assistant/iOS) or the [Android GitHub repository](https://github.com/home-assistant/android).
+
+**For feature requests**
+*   Feature requests or ideas can be suggested in our [feature requests section on our community forums](https://community.home-assistant.io/c/feature-requests/13).
 
 **For issues, corrections or amendments to these docs**
 *   Either use the edit button on the page you wish to amend (docs are written in [Markdown](https://daringfireball.net/projects/markdown/syntax)), you will need a [GitHub](https://www.github.com) account to submit changes; or


### PR DESCRIPTION
This PR adjusts the documentation of the companion app to fix an incorrect statement on where to suggest new features.

See also: https://www.home-assistant.io/help

We should not send users to all kinds of different places or create separate rules across the project org.

Feature requests in our issue trackers should be closed as a follow up.