### PR TITLE
Fix broken link on actionable-notifications

### DIFF
--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -266,7 +266,7 @@ The above example will wait, until the notification action is performed. This mi
 
 -   You can use a [time out](https://www.home-assistant.io/docs/scripts/#wait-timeout) to allow new executions of the script. However, this will lead to dangling notifications on your mobile phone. 
 -   It is possible to [clear notifications](https://companion.home-assistant.io/docs/notifications/notifications-basic#clearing) which can be combined with timeouts and parallel execution mode to achieve good results. 
--   In Android you can listen to the [notification cleared event](https://companion.home-assistant.io/docs/notifications/notification-cleared/event) that is fired when the notification is closed, and handle it accordingly. This can be achieved by adding the following lines
+-   In Android you can listen to the [notification cleared event](https://companion.home-assistant.io/docs/notifications/notification-cleared) that is fired when the notification is closed, and handle it accordingly. This can be achieved by adding the following lines
   ```
         - platform: event
           event_type: mobile_app_notification_cleared


### PR DESCRIPTION
I just like to fix an broken link on the page actionable-notifications.
The link of "notification cleared event" is currently not working