### PR TITLE
Remove beta tags for 2022.10.0 release

### DIFF
--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -101,7 +101,7 @@ You can change the frequency of sensor updates by navigating to [Settings](https
 | `sensor.bluetooth_connection` | [See Below](#bluetooth-sensor) | The state of the sensor will reflect the total number of connected bluetooth devices. |
 | `sensor.current_time_zone` | [See Below](#current-time-zone-sensor) | The current time zone the device is in. |
 | `sensor.current_version` | None | The current installed version of the application. |
-| [Dynamic Color](#dynamic-color-sensor) | RGB Color | The hexadecimal color value for the accent color used in the current device theme. <span class="beta">BETA</span> |
+| [Dynamic Color](#dynamic-color-sensor) | RGB Color | The hexadecimal color value for the accent color used in the current device theme. |
 | `sensor.do_not_disturb` | None | The state of do not disturb on the device. |
 | `sensor.geocoded_location` | [See Below](#geocoded-location-sensor) | Calculated address based on GPS data. |
 | `binary_sensor.high_accuracy_mode` | None | The state of high accuracy mode on the device. |
@@ -354,7 +354,7 @@ This sensor will represent the current installed version of the Android app.
 
 
 ## Dynamic Color Sensor
-![Android](/assets/android.svg) <span class="beta">BETA</span> Only available on devices with support for Material 3 Dynamic color.
+![Android](/assets/android.svg) Only available on devices with support for Material 3 Dynamic color.
 
 This sensors state will be a hexadecimal color value for the accent color used in the current device theme. [Dynamic color](https://m3.material.io/styles/color/dynamic-color/overview) can either be derived from the wallpaper or chosen by the user. An attribute also exists for `rgb_color` in case you wanted to use this color in an automation for the [`light.turn_on`](https://www.home-assistant.io/integrations/light/#service-lightturn_on) service call. This sensor uses the [Dynamic Colors API](https://developer.android.com/reference/com/google/android/material/color/DynamicColors).
 
@@ -406,11 +406,7 @@ Geocoding is handled directly by iOS's [MapKit](https://developer.apple.com/docu
 | `premises` | The premises for the placemark, if available. ![Android](/assets/android.svg) |
 | `url` | The URL for the placemark, if available. ![Android](/assets/android.svg) |
 
-![Android](/assets/android.svg) Android users will have a sensor setting for the minimum required accuracy, that defaults to 200m. Users may adjust this to fit their own needs if they find inaccurate reports or not enough reports. This sensor requires either [Background Location](https://developer.android.com/reference/android/Manifest.permission#ACCESS_BACKGROUND_LOCATION) or [Fine Location](https://developer.android.com/reference/android/Manifest.permission#ACCESS_FINE_LOCATION) permissions, depending on what version of Android you run. All attributes will be lowercase and all spaces are replaced with an underscore. The sensor will only send an update if it is accurate and recent. The sensor will also update with location updates if location tracking is enabled.
-
-![Android](/assets/android.svg) <span class='beta'>BETA</span>
-
-A setting also exists to keep the sensor up to date with location updates, by default this is turned off.
+![Android](/assets/android.svg) Android users will have a sensor setting for the minimum required accuracy, that defaults to 200m. Users may adjust this to fit their own needs if they find inaccurate reports or not enough reports. This sensor requires either [Background Location](https://developer.android.com/reference/android/Manifest.permission#ACCESS_BACKGROUND_LOCATION) or [Fine Location](https://developer.android.com/reference/android/Manifest.permission#ACCESS_FINE_LOCATION) permissions, depending on what version of Android you run. All attributes will be lowercase and all spaces are replaced with an underscore. The sensor will only send an update if it is accurate and recent. The sensor will also update with location updates if location tracking is enabled. A setting also exists to keep the sensor up to date with location updates, by default this is turned off.
 
 ![iOS](/assets/iOS.svg) and ![macOS](/assets/macOS.svg) users will have a sensor setting for whether to use the name of an active Zone if present instead of the geocoded state, defaulting to not using it.
 
@@ -496,8 +492,6 @@ This sensors state will be the date and time of the last reboot from the device 
 ![Android](/assets/android.svg)
 
 For android this sensors state will reflect the [intent](https://developer.android.com/reference/android/content/Intent) of the most recent update sent. Additionally the sensor offers settings to allow the user to receive [app events](../integrations/app-events.md) from other Android apps that broadcast an intent. Users can register for as many intents as they like, an event will be sent to Home Assistant once the intent has been received. Once you save an intent be sure to restart the application to register for the intent.
-
-![Android](/assets/android.svg) <span class='beta'>BETA</span>
 
 If you notice an intent you registered for in settings is no longer being triggered by the app then you will need to add categories that the intent is expecting. You can add categories after the intent by editing the setting for the intent and adding a `,` followed by the category. If more than 1 category is required then you will need to add each category followed by a `,` until there are no more categories to add. For example if your intent requires 2 categories the format will be: `intent,category1,category2`. After saving the intent and category make sure to restart the application.
 

--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -137,7 +137,7 @@ You can also open the notification history when using the format `settings://not
   uri: "settings://notification_history"
 ```
 
-![Android](/assets/android.svg) <span class='beta'>BETA</span>
+![Android](/assets/android.svg)
 
 You can also use an [intent scheme URI](https://developer.chrome.com/docs/multidevice/android/intents/#syntax) to start an action in an installed application.
 
@@ -147,7 +147,7 @@ You can also use an [intent scheme URI](https://developer.chrome.com/docs/multid
   uri: "intent://scan/#Intent;scheme=zxing;package=com.google.zxing.client.android;end"
 ```
 
-![Android](/assets/android.svg) <span class='beta'>BETA</span>
+![Android](/assets/android.svg)
 
 You can send a specific [deep link](https://developer.android.com/training/app-links#deep-links) to an app by using `deep-link://<deep_link>` where `<deep_link>` is the actual deep link you wish to send.
 

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -61,8 +61,8 @@ When tapping on a notification, you can choose to open a URL, which can fall int
 - ![Android](/assets/android.svg) An application using `app://<package name>` where `<package name>` is replaced with the actual package you wish to open.
 - ![Android](/assets/android.svg) The More Info panel of an entity using `entityId:<entity_ID>` where `<entity_id>` is replaced with the entity ID you wish to view. Ex: `entityId:sun.sun`.
 - ![Android](/assets/android.svg) You can also open the notification history by using `settings://notification_history`
-- ![Android](/assets/android.svg) <span class='beta'>BETA</span> You can also use an [intent scheme URI](https://developer.chrome.com/docs/multidevice/android/intents/#syntax) to start an action in an installed application.
-- ![Android](/assets/android.svg) <span class='beta'>BETA</span> You can send a specific [deep link](https://developer.android.com/training/app-links#deep-links) to an app by using `deep-link://<deep_link>` where `<deep_link>` is the actual deep link you wish to send.
+- ![Android](/assets/android.svg) You can also use an [intent scheme URI](https://developer.chrome.com/docs/multidevice/android/intents/#syntax) to start an action in an installed application.
+- ![Android](/assets/android.svg) You can send a specific [deep link](https://developer.android.com/training/app-links#deep-links) to an app by using `deep-link://<deep_link>` where `<deep_link>` is the actual deep link you wish to send.
 
 For relative URLs, you can open a lovelace view in the format `/lovelace/test` where `test` is replaced by your defined [`path`](https://www.home-assistant.io/dashboards/views#path) in the defined view or a lovelace dashboard in the format `/lovelace-dashboard/view` where `/lovelace-dashboard/` is replaced by your defined [`dashboard`](https://www.home-assistant.io/dashboards/dashboards/) URL and `view` is replaced by the defined [`path`](https://www.home-assistant.io/dashboards/views#path) within that dashboard.
 

--- a/docs/troubleshooting/networking.md
+++ b/docs/troubleshooting/networking.md
@@ -41,7 +41,7 @@ If you want to (or have to) use Nabu Casa Cloud or a different URL depending on 
 -  ![Android](/assets/android.svg) Manually change your Home Assistant's external URL to your Nabu Casa Cloud URL.
 
 :::note Using the BSSID instead of SSID
-![Android](/assets/android.svg) <span class='beta'>BETA</span> You can also enter a wifi network BSSID in the app's settings in case you have multiple access points with the same SSID, and only want to use the internal URL when connected to a specific access point. To do so, add a new SSID with the name `BSSID:` followed by the BSSID (for example: `BSSID:1A:2B:3C:4D:5E:6F`).
+![Android](/assets/android.svg) You can also enter a wifi network BSSID in the app's settings in case you have multiple access points with the same SSID, and only want to use the internal URL when connected to a specific access point. To do so, add a new SSID with the name `BSSID:` followed by the BSSID (for example: `BSSID:1A:2B:3C:4D:5E:6F`).
 :::
 
 ## Addendum: CG-NAT


### PR DESCRIPTION
Luckily the release is not live yet. Leaving other beta tags as we had some merges for tonight's beta release.