### PR TITLE
Change Wear OS Sensor list to a table

### DIFF
--- a/docs/wear-os/sensors.md
+++ b/docs/wear-os/sensors.md
@@ -2,7 +2,6 @@
 title: "Sensors"
 id: 'sensors'
 ---
-![Android](/assets/android.svg)
 
 The Wear OS app also offers [sensors](../core/sensors.md#android-sensors) to consume your wearable data in Home Assistant, please refer to the link to learn more about how sensors update on Android. Not all sensors offered by the phone app will be offered by the Wear OS app. Please see the list below for what sensors are currently supported by the Wear OS app. If a sensor requires permissions you will be prompted to accept, otherwise the sensor will not enable and send data.
 
@@ -16,15 +15,15 @@ Sensor updates are dependent upon the watch having data connectivity and the app
 
 | Sensor | Attributes | Description |
 | --------- | --------- | ----------- |
-| [Battery](../core/sensors.md#battery-sensors) (enabled by default) | None | Several different sensors around the state of the devices battery. |
 | `sensor.activity_state` | Exercise type, Time | A sensor to reflect the current user activity state which can be either: asleep, exercise, passive or unknown. Data is provided by [Health Services API](https://developer.android.com/training/wearables/health-services/passive#useractivityinfo). Only available on Wear OS 3 devices. <span class='beta'>BETA</span>  |
 | [App Data](../core/sensors.md#app-data-sensors) | None | Sensors that show how much data was sent or received by the app. <span class='beta'>BETA</span> |
 | [App Importance](../core/sensors.md#app-importance-sensor) | None | The current importance of the app to determine if its in the foreground or cached. <span class='beta'>BETA</span> |
 | [App Memory](../core/sensors.md#app-memory-sensor) | None | Information about the memory that is available for the app. <span class='beta'>BETA</span> |
 | [App Usage](../core/sensors.md#app-usage-sensors) | None | Sensors that represent how the app is treated based on its usage. <span class='beta'>BETA</span> |
 | [Audio](../core/sensors.md#audio-sensors) | None | Several different sensors around different types of audio detection from the device. <span class='beta'>BETA</span> |
-| [Current Version](../core/sensors.md#current-version-sensor) | None | The current installed version of the application. <span class='beta'>BETA</span> |
+| [Battery](../core/sensors.md#battery-sensors) (enabled by default) | None | Several different sensors around the state of the devices battery. |
 | `binary_sensor.bedtime_mode` | None | A sensor to reflect the state of Bedtime mode on the device. For best results enable Do Not Disturb or Interactive sensor. Only available on Wear OS 3 devices <span class='beta'>BETA</span> |
+| [Current Version](../core/sensors.md#current-version-sensor) | None | The current installed version of the application. <span class='beta'>BETA</span> |
 | [Do Not Disturb](../core/sensors.md#do-not-disturb-sensor) | None | The state of do not disturb on the device. <span class='beta'>BETA</span> |
 | [Doze](../core/sensors.md#doze-sensor) | None | Whether or not the device is in doze mode. <span class='beta'>BETA</span> |
 | [Interactive](../core/sensors.md#interactive-sensor) | None | Whether or not the device is in an interactive state. <span class='beta'>BETA</span> |

--- a/docs/wear-os/sensors.md
+++ b/docs/wear-os/sensors.md
@@ -1,0 +1,38 @@
+---
+title: "Sensors"
+id: 'sensors'
+---
+![Android](/assets/android.svg)
+
+The Wear OS app also offers [sensors](../core/sensors.md#android-sensors) to consume your wearable data in Home Assistant, please refer to the link to learn more about how sensors update on Android. Not all sensors offered by the phone app will be offered by the Wear OS app. Please see the list below for what sensors are currently supported by the Wear OS app. If a sensor requires permissions you will be prompted to accept, otherwise the sensor will not enable and send data.
+
+Its important to note that sensor updates require the app to post a notification to the device in order to prevent it from being killed by the OS. You can go to into Wear device settings and turn off the SensorWorker Notification channel to stop these notifications from buzzing on your wrist.
+
+:::info
+Sensor updates are dependent upon the watch having data connectivity and the app being allowed to send an update. Some devices implement stricter battery saving techniques than others so updates may not happen as frequently as you would expect.
+:::
+
+### Sensor List
+
+| Sensor | Attributes | Description |
+| --------- | --------- | ----------- |
+| [Battery](../core/sensors.md#battery-sensors) (enabled by default) | None | Several different sensors around the state of the devices battery. |
+| `sensor.activity_state` | Exercise type, Time | A sensor to reflect the current user activity state which can be either: asleep, exercise, passive or unknown. Data is provided by [Health Services API](https://developer.android.com/training/wearables/health-services/passive#useractivityinfo). Only available on Wear OS 3 devices. <span class='beta'>BETA</span>  |
+| [App Data](../core/sensors.md#app-data-sensors) | None | Sensors that show how much data was sent or received by the app. <span class='beta'>BETA</span> |
+| [App Importance](../core/sensors.md#app-importance-sensor) | None | The current importance of the app to determine if its in the foreground or cached. <span class='beta'>BETA</span> |
+| [App Memory](../core/sensors.md#app-memory-sensor) | None | Information about the memory that is available for the app. <span class='beta'>BETA</span> |
+| [App Usage](../core/sensors.md#app-usage-sensors) | None | Sensors that represent how the app is treated based on its usage. <span class='beta'>BETA</span> |
+| [Audio](../core/sensors.md#audio-sensors) | None | Several different sensors around different types of audio detection from the device. <span class='beta'>BETA</span> |
+| [Current Version](../core/sensors.md#current-version-sensor) | None | The current installed version of the application. <span class='beta'>BETA</span> |
+| `binary_sensor.bedtime_mode` | None | A sensor to reflect the state of Bedtime mode on the device. For best results enable Do Not Disturb or Interactive sensor. Only available on Wear OS 3 devices <span class='beta'>BETA</span> |
+| [Do Not Disturb](../core/sensors.md#do-not-disturb-sensor) | None | The state of do not disturb on the device. <span class='beta'>BETA</span> |
+| [Doze](../core/sensors.md#doze-sensor) | None | Whether or not the device is in doze mode. <span class='beta'>BETA</span> |
+| [Interactive](../core/sensors.md#interactive-sensor) | None | Whether or not the device is in an interactive state. <span class='beta'>BETA</span> |
+| [Last Update](../core/sensors.md#last-update-trigger-sensor) | None | The state will reflect the intent that caused the last update to get sent. <span class='beta'>BETA</span> |
+| [Network](../core/sensors.md#connection-type-sensor) | None | Several different sensors around the state of WiFi. <span class='beta'>BETA</span> |
+| [Next Alarm](../core/sensors.md#next-alarm-sensor) | [See Attributes](../core/sensors.md#next-alarm-sensor) | Date of the next scheduled alarm. <span class='beta'>BETA</span> |
+| `binary_sensor.on_body_sensor` | None | A sensor to indicate whether the wearable believes it is on the body or not. This sensor makes use of the [low latency off body detection](https://developer.android.com/reference/android/hardware/Sensor#TYPE_LOW_LATENCY_OFFBODY_DETECT) sensor. <span class='beta'>BETA</span> |
+| [Power Save](../core/sensors.md#power-save-sensor) | None | Whether or not the device is in power saving mode. <span class='beta'>BETA</span> |
+| [Steps](../core//sensors.md#pedometer-sensors) | None | The number of steps taken from the user since the last device reboot. Requires activity recognition permissions on supported devies. <span class='beta'>BETA</span> |
+| `binary_sensor.theater_mode` | None | A sensor to reflect the state of Theater mode on the device. For best results enable the Interactive sensor. <span class='beta'>BETA</span> |
+| `binary_sensor.wet_mode` | None | A sensor to indicate the state of Wet Mode on the current device. This sensor is also known as Touch Lock or Water Lock on some devices. This is a special mode where the user must press and hold the crown/power button for 2 seconds to re-enable touch. <span class='beta'>BETA</span> |

--- a/docs/wear-os/sensors.md
+++ b/docs/wear-os/sensors.md
@@ -5,7 +5,7 @@ id: 'sensors'
 
 The Wear OS app also offers [sensors](../core/sensors.md#android-sensors) to consume your wearable data in Home Assistant, please refer to the link to learn more about how sensors update on Android. Not all sensors offered by the phone app will be offered by the Wear OS app. Please see the list below for what sensors are currently supported by the Wear OS app. If a sensor requires permissions you will be prompted to accept, otherwise the sensor will not enable and send data.
 
-Its important to note that sensor updates require the app to post a notification to the device in order to prevent it from being killed by the OS. You can go to into Wear device settings and turn off the SensorWorker Notification channel to stop these notifications from buzzing on your wrist.
+It's important to note that sensor updates require the app to post a notification to the device in order to prevent it from being killed by the OS. You can go to into Wear device settings and turn off the SensorWorker Notification channel to stop these notifications from buzzing on your wrist.
 
 :::info
 Sensor updates are dependent upon the watch having data connectivity and the app being allowed to send an update. Some devices implement stricter battery saving techniques than others so updates may not happen as frequently as you would expect.

--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -74,28 +74,34 @@ Hint: use a [template sensor](https://www.home-assistant.io/integrations/templat
 
 The Wear OS app also offers [sensors](../core/sensors.md#android-sensors) to consume your wearable data in Home Assistant, please refer to the link to learn more about how sensors update on Android. Not all sensors offered by the phone app will be offered by the Wear OS app. Please see the list below for what sensors are currently supported by the Wear OS app. If a sensor requires permissions you will be prompted to accept, otherwise the sensor will not enable and send data.
 
-List of supported sensors:
-
-*  [Battery](../core/sensors.md#battery-sensors) (enabled by default)
-
-<span class='beta'>BETA</span>
-
-*  Activity State - A sensor to reflect the current user activity state which can be either: asleep, exercise, passive or unknown. Data is provided by [Health Services API](https://developer.android.com/training/wearables/health-services/passive#useractivityinfo). Only available on Wear OS 3 devices.
-*  [App Data](../core/sensors.md#app-data-sensors), [App Importance](../core/sensors.md#app-importance-sensor), [App Memory](../core/sensors.md#app-memory-sensor), [App Usage](../core/sensors.md#app-usage-sensors), [Current Version](../core/sensors.md#current-version-sensor)
-*  [Audio](../core/sensors.md#audio-sensors)
-*  Bedtime Mode - A sensor to reflect the state of Bedtime mode on the device. For best results enable Do Not Disturb or Interactive sensor. Only available on Wear OS 3 devices
-*  [Do Not Disturb](../core/sensors.md#do-not-disturb-sensor)
-*  [Doze](../core/sensors.md#doze-sensor), [Interactive](../core/sensors.md#interactive-sensor), [Power Save](../core/sensors.md#power-save-sensor)
-*  [Last Update](../core/sensors.md#last-update-trigger-sensor)
-*  [Network](../core/sensors.md#connection-type-sensor)
-*  [Next Alarm](../core/sensors.md#next-alarm-sensor)
-*  On Body - A sensor to indicate whether the wearable believes it is on the body or not. This sensor makes use of the [low latency off body detection](https://developer.android.com/reference/android/hardware/Sensor#TYPE_LOW_LATENCY_OFFBODY_DETECT) sensor.
-*  [Steps](../core//sensors.md#pedometer-sensors)
-*  Theater Mode - A sensor to reflect the state of Theater mode on the device. For best results enable the Interactive sensor.
-*  Wet Mode - A sensor to indicate the state of Wet Mode on the current device. This sensor is also known as Touch Lock or Water Lock on some devices. This is a special mode where the user must press and hold the crown/power button for 2 seconds to re-enable touch.
-
 Its important to note that sensor updates require the app to post a notification to the device in order to prevent it from being killed by the OS. You can go to into Wear device settings and turn off the SensorWorker Notification channel to stop these notifications from buzzing on your wrist.
 
 :::info
-Sensors updates are dependent upon the watch having data connectivity and the app being allowed to send an update. Some devices implement stricter battery saving techniques than others so updates may not happen as frequently as you would expect.
+Sensor updates are dependent upon the watch having data connectivity and the app being allowed to send an update. Some devices implement stricter battery saving techniques than others so updates may not happen as frequently as you would expect.
 :::
+
+### Sensor List
+
+| Sensor | Attributes | Description |
+| --------- | --------- | ----------- |
+| [Battery](../core/sensors.md#battery-sensors) (enabled by default) | None | Several different sensors around the state of the devices battery. |
+| <span class='beta'>BETA</span> | | |
+| `sensor.activity_state` | Exercise type, Time | A sensor to reflect the current user activity state which can be either: asleep, exercise, passive or unknown. Data is provided by [Health Services API](https://developer.android.com/training/wearables/health-services/passive#useractivityinfo). Only available on Wear OS 3 devices. |
+| [App Data](../core/sensors.md#app-data-sensors) | None | Sensors that show how much data was sent or received by the app.|
+| [App Importance](../core/sensors.md#app-importance-sensor) | None | The current importance of the app to determine if its in the foreground or cached. |
+| [App Memory](../core/sensors.md#app-memory-sensor) | None | Information about the memory that is available for the app. |
+| [App Usage](../core/sensors.md#app-usage-sensors) | None | Sensors that represent how the app is treated based on its usage. |
+| [Audio](../core/sensors.md#audio-sensors) | None | Several different sensors around different types of audio detection from the device. |
+| [Current Version](../core/sensors.md#current-version-sensor) | None | The current installed version of the application. |
+| `binary_sensor.bedtime_mode` | None | A sensor to reflect the state of Bedtime mode on the device. For best results enable Do Not Disturb or Interactive sensor. Only available on Wear OS 3 devices |
+| [Do Not Disturb](../core/sensors.md#do-not-disturb-sensor) | None | The state of do not disturb on the device. |
+| [Doze](../core/sensors.md#doze-sensor) | None | Whether or not the device is in doze mode. |
+| [Interactive](../core/sensors.md#interactive-sensor) | None | Whether or not the device is in an interactive state. |
+| [Last Update](../core/sensors.md#last-update-trigger-sensor) | None | The state will reflect the intent that caused the last update to get sent. |
+| [Network](../core/sensors.md#connection-type-sensor) | None | Several different sensors around the state of WiFi. |
+| [Next Alarm](../core/sensors.md#next-alarm-sensor) | [See Attributes](../core/sensors.md#next-alarm-sensor) | Date of the next scheduled alarm. |
+| `binary_sensor.on_body_sensor` | None | A sensor to indicate whether the wearable believes it is on the body or not. This sensor makes use of the [low latency off body detection](https://developer.android.com/reference/android/hardware/Sensor#TYPE_LOW_LATENCY_OFFBODY_DETECT) sensor. |
+| [Power Save](../core/sensors.md#power-save-sensor) | None | Whether or not the device is in power saving mode. |
+| [Steps](../core//sensors.md#pedometer-sensors) | None | The number of steps taken from the user since the last device reboot. Requires activity recognition permissions on supported devies. |
+| `binary_sensor.theater_mode` | None | A sensor to reflect the state of Theater mode on the device. For best results enable the Interactive sensor. |
+| `binary_sensor.wet_mode` | None | A sensor to indicate the state of Wet Mode on the current device. This sensor is also known as Touch Lock or Water Lock on some devices. This is a special mode where the user must press and hold the crown/power button for 2 seconds to re-enable touch. |

--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -7,7 +7,7 @@ id: "wear-os"
 
 You can access Home Assistant directly from your Wear OS watch, even when not connected to your phone using a WiFi or cellular connection on the watch or when using an iPhone. 
 
-The app does not support all Home Assistant features. Keep an eye out on this page as the app is enhanced with new features!
+The app does not support all Home Assistant features. Keep an eye out on this page as the app is enhanced with new features! Take a look at the [Sensors!](./wear-os/sensors)
 
 ## Home Screen
 

--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -3,8 +3,6 @@ title: "Overview"
 id: "wear-os"
 ---
 
-![Android](/assets/android.svg)
-
 You can access Home Assistant directly from your Wear OS watch, even when not connected to your phone using a WiFi or cellular connection on the watch or when using an iPhone. 
 
 The app does not support all Home Assistant features. Keep an eye out on this page as the app is enhanced with new features! Take a look at the [Sensors!](sensors.md)

--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -69,39 +69,3 @@ An entity state complication can be displayed on your watchface. The complicatio
 The complications are updated automatically whenever the screen is turned on and roughly every 15 minutes. You can force a complication to update by tapping it on the watch face.
 
 Hint: use a [template sensor](https://www.home-assistant.io/integrations/template/#state-based-template-binary-sensors-buttons-numbers-selects-and-sensors) for full flexibility.
-
-## Sensors
-
-The Wear OS app also offers [sensors](../core/sensors.md#android-sensors) to consume your wearable data in Home Assistant, please refer to the link to learn more about how sensors update on Android. Not all sensors offered by the phone app will be offered by the Wear OS app. Please see the list below for what sensors are currently supported by the Wear OS app. If a sensor requires permissions you will be prompted to accept, otherwise the sensor will not enable and send data.
-
-Its important to note that sensor updates require the app to post a notification to the device in order to prevent it from being killed by the OS. You can go to into Wear device settings and turn off the SensorWorker Notification channel to stop these notifications from buzzing on your wrist.
-
-:::info
-Sensor updates are dependent upon the watch having data connectivity and the app being allowed to send an update. Some devices implement stricter battery saving techniques than others so updates may not happen as frequently as you would expect.
-:::
-
-### Sensor List
-
-| Sensor | Attributes | Description |
-| --------- | --------- | ----------- |
-| [Battery](../core/sensors.md#battery-sensors) (enabled by default) | None | Several different sensors around the state of the devices battery. |
-| <span class='beta'>BETA</span> | | |
-| `sensor.activity_state` | Exercise type, Time | A sensor to reflect the current user activity state which can be either: asleep, exercise, passive or unknown. Data is provided by [Health Services API](https://developer.android.com/training/wearables/health-services/passive#useractivityinfo). Only available on Wear OS 3 devices. |
-| [App Data](../core/sensors.md#app-data-sensors) | None | Sensors that show how much data was sent or received by the app.|
-| [App Importance](../core/sensors.md#app-importance-sensor) | None | The current importance of the app to determine if its in the foreground or cached. |
-| [App Memory](../core/sensors.md#app-memory-sensor) | None | Information about the memory that is available for the app. |
-| [App Usage](../core/sensors.md#app-usage-sensors) | None | Sensors that represent how the app is treated based on its usage. |
-| [Audio](../core/sensors.md#audio-sensors) | None | Several different sensors around different types of audio detection from the device. |
-| [Current Version](../core/sensors.md#current-version-sensor) | None | The current installed version of the application. |
-| `binary_sensor.bedtime_mode` | None | A sensor to reflect the state of Bedtime mode on the device. For best results enable Do Not Disturb or Interactive sensor. Only available on Wear OS 3 devices |
-| [Do Not Disturb](../core/sensors.md#do-not-disturb-sensor) | None | The state of do not disturb on the device. |
-| [Doze](../core/sensors.md#doze-sensor) | None | Whether or not the device is in doze mode. |
-| [Interactive](../core/sensors.md#interactive-sensor) | None | Whether or not the device is in an interactive state. |
-| [Last Update](../core/sensors.md#last-update-trigger-sensor) | None | The state will reflect the intent that caused the last update to get sent. |
-| [Network](../core/sensors.md#connection-type-sensor) | None | Several different sensors around the state of WiFi. |
-| [Next Alarm](../core/sensors.md#next-alarm-sensor) | [See Attributes](../core/sensors.md#next-alarm-sensor) | Date of the next scheduled alarm. |
-| `binary_sensor.on_body_sensor` | None | A sensor to indicate whether the wearable believes it is on the body or not. This sensor makes use of the [low latency off body detection](https://developer.android.com/reference/android/hardware/Sensor#TYPE_LOW_LATENCY_OFFBODY_DETECT) sensor. |
-| [Power Save](../core/sensors.md#power-save-sensor) | None | Whether or not the device is in power saving mode. |
-| [Steps](../core//sensors.md#pedometer-sensors) | None | The number of steps taken from the user since the last device reboot. Requires activity recognition permissions on supported devies. |
-| `binary_sensor.theater_mode` | None | A sensor to reflect the state of Theater mode on the device. For best results enable the Interactive sensor. |
-| `binary_sensor.wet_mode` | None | A sensor to indicate the state of Wet Mode on the current device. This sensor is also known as Touch Lock or Water Lock on some devices. This is a special mode where the user must press and hold the crown/power button for 2 seconds to re-enable touch. |

--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -7,7 +7,7 @@ id: "wear-os"
 
 You can access Home Assistant directly from your Wear OS watch, even when not connected to your phone using a WiFi or cellular connection on the watch or when using an iPhone. 
 
-The app does not support all Home Assistant features. Keep an eye out on this page as the app is enhanced with new features! Take a look at the [Sensors!](./wear-os/sensors)
+The app does not support all Home Assistant features. Keep an eye out on this page as the app is enhanced with new features! Take a look at the [Sensors!](sensors.md)
 
 ## Home Screen
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -58,7 +58,8 @@ module.exports = {
       'meta-quest/meta-quest'
     ],
     'Wear OS': [
-      'wear-os/wear-os'
+      'wear-os/wear-os',
+      'wear-os/sensors'
     ],
     'Troubleshooting': [
       'troubleshooting/faqs',


### PR DESCRIPTION
Changes the Wear OS Sensor list to a table to match other sensor lists across the documentation website