### PR TITLE
Remove Android beta label for location tracking level

### DIFF
--- a/docs/core/location.md
+++ b/docs/core/location.md
@@ -67,7 +67,7 @@ If you want to know more about the specifics of these attributes, please refer t
 
 ## Manage location tracking level
 
-When using core 2022.2 with ![iOS](/assets/iOS.svg) 2022.2 or ![Android](/assets/android.svg) <span class="beta">BETA</span> or later, you can configure how locations are sent on a per-server basis in the Companion App Settings:
+When using core 2022.2 with ![iOS](/assets/iOS.svg) 2022.2 or ![Android](/assets/android.svg) 2022.11 or later, you can configure how locations are sent on a per-server basis in the Companion App Settings:
 
  - ![iOS](/assets/iOS.svg) Open the server's settings and change the Location Sent setting under Privacy.
  - ![Android](/assets/android.svg) Go to Manage Sensors > Background Location and change the Location Sent setting.


### PR DESCRIPTION
The location tracking level feature is included in the latest Android stable release, this label was missed.