### PR TITLE
Doc Change: Clarified when notifications are clearable

### DIFF
--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -149,7 +149,7 @@ Clearing a notification on iOS requires app version 2021.5 or later.
 
 You can clear an existing notification which has a tag by sending `clear_notification`.
 
-Platform limitations may require the companion app to be have been recently used to clear the notification.
+Platform limitations may require the companion app to have been recently used to clear the notification: this applies for all iOS notifications, and any Android notifications not marked as critical.
 
 ![iOS](/assets/iOS.svg) will only clear the most recent [critical notification](critical.md) from a given tag.
 

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -149,6 +149,8 @@ Clearing a notification on iOS requires app version 2021.5 or later.
 
 You can clear an existing notification which has a tag by sending `clear_notification`.
 
+Platform limitations may require the companion app to be have been recently used to clear the notification.
+
 ![iOS](/assets/iOS.svg) will only clear the most recent [critical notification](critical.md) from a given tag.
 
 ```yaml


### PR DESCRIPTION
Because of platform limitations, the application must be in memory to delete notifications.

Adding note to this section stating words to that effect.

https://community.home-assistant.io/t/clear-notification-not-working/319502/2