### PR TITLE
Remove mdx-js/react

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@docusaurus/core": "^2.2.0",
     "@docusaurus/preset-classic": "^2.2.0",
     "@easyops-cn/docusaurus-search-local": "^0.33.6",
-    "@mdx-js/react": "^1.6.21",
     "by-node-env": "^2.0.1",
     "clsx": "^1.2.1",
     "react": "^17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1731,7 +1731,7 @@
     unist-builder "2.0.3"
     unist-util-visit "2.0.3"
 
-"@mdx-js/react@^1.6.21", "@mdx-js/react@^1.6.22":
+"@mdx-js/react@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/react/-/react-1.6.22.tgz#ae09b4744fddc74714ee9f9d6f17a66e77c43573"
   integrity sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==


### PR DESCRIPTION
Removes @mdx-js/react, which is already a subdeb.

unblocks #874 