### PR TITLE
Remove actionName from docs

### DIFF
--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -345,7 +345,7 @@ automation:
       - platform: event
         event_type: ios.notification_action_fired
         event_data:
-          actionName: "SOUND_ALARM"
+          action: "SOUND_ALARM"
     action:
       ...
 # replacement


### PR DESCRIPTION
Replace ```actionName``` with ```action```.

```actionName``` no longer works.