### PR TITLE
Remove Android notification command change comments

### DIFF
--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -545,7 +545,6 @@ automation:
             tts_text: Motion has been detected
 ```
 
-
 ### Chronometer Notifications
 
 You can create notifications with a count up/down timer (chronometer) by passing the `chronometer` and `when` options. This feature requires at least Android 7.0.

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -545,13 +545,6 @@ automation:
             tts_text: Motion has been detected
 ```
 
-Please see the below table for new parameters to use after updating the Android app to 2022.8+:
-
-| Old Parameter | New Parameter |
-|--------|--------|
-| `channel` | `media_stream` |
-| `title` | `tts_text` |
-
 
 ### Chronometer Notifications
 

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -498,7 +498,6 @@ automation:
             media_package_name: "com.spotify.music"
 ```
 
-
 ## Request Location Updates
 
 ![Android](/assets/android.svg) ![iOS](/assets/iOS.svg)
@@ -552,7 +551,6 @@ automation:
           data:
             command: "vibrate"
 ```
-
 
 ## Screen Brightness Level
 
@@ -696,7 +694,6 @@ automation:
             media_stream: "music_stream"
             command: 20
 ```
-
 
 ## Webview
 

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -96,16 +96,6 @@ automation:
 
 In order to use the Intent Action `android.intent.action.CALL` you will also need to grant the app Phone permissions. If not granted the app will direct you to the app info screen to grant the permissions along with a toast message letting you know the missing permissions.
 
-Please see the below table for new parameters to use after updating the Android app to 2022.8+:
-
-| Old Parameter | New Parameter |
-|--------|--------|
-| `channel` | `intent_package_name` |
-| `group` | `intent_extras` |
-| `subject` | `intent_type` |
-| `tag` | `intent_action` |
-| `title` | `intent_uri` |
-
 
 ## App lock
 
@@ -236,8 +226,6 @@ automation:
             ble_uuid: "b4306bba-0e3a-44df-9518-dc74284e8214"
 ```
 
-If you have updated the Android app to 2022.8 you must use `command` in place of `title`.
-
 ## Beacon Monitor
 
 ![Android](/assets/android.svg) <br />
@@ -279,8 +267,6 @@ automation:
           data:
             command: "turn_off"
 ```
-
-If you have updated the Android app to 2022.8 you must use `command` in place of `title`.
 
 ## Broadcast Intent
 
@@ -392,15 +378,6 @@ automation:
             intent_action: "sample.intent.SAMPLE"
 ```
 
-
-Please see the below table for new parameters to use after updating the Android app to 2022.8+:
-
-| Old Parameter | New Parameter |
-|--------|--------|
-| `channel` | `intent_package_name` |
-| `group` | `intent_extras` |
-| `title` | `intent_action` |
-
 ## Do Not Disturb
 
 ![Android](/assets/android.svg) &nbsp;Android 6+ only
@@ -432,8 +409,6 @@ automation:
           data:
             command: "priority_only"
 ```
-
-If you have updated the Android app to 2022.8 you must use `command` in place of `title`.
 
 ## High accuracy mode
 
@@ -471,8 +446,6 @@ automation:
             high_accuracy_update_interval: 60
             command: "high_accuracy_set_update_interval"
 ```
-
-If you have updated the Android app to 2022.8 you must use `command` in place of `title`.
 
 ## Launch App
 
@@ -524,13 +497,6 @@ automation:
             media_command: "pause"
             media_package_name: "com.spotify.music"
 ```
-
-Please see the below table for new parameters to use after updating the Android app to 2022.8+:
-
-| Old Parameter | New Parameter |
-|--------|--------|
-| `channel` | `media_package_name` |
-| `title` | `media_command` |
 
 
 ## Request Location Updates
@@ -586,8 +552,6 @@ automation:
           data:
             command: "vibrate"
 ```
-
-If you have updated the Android app to 2022.8 you must use `command` in place of `title`.
 
 
 ## Screen Brightness Level
@@ -733,13 +697,6 @@ automation:
             command: 20
 ```
 
-Please see the below table for new parameters to use after updating the Android app to 2022.8+:
-
-| Old Parameter | New Parameter |
-|--------|--------|
-| `channel` | `media_stream` |
-| `title` | `command` |
-
 
 ## Webview
 
@@ -761,5 +718,3 @@ automation:
           data:
             command: "/lovelace/settings"
 ```
-
-If you have updated the Android app to 2022.8 you must use `command` in place of `title`.

--- a/docs/notifications/critical.md
+++ b/docs/notifications/critical.md
@@ -117,13 +117,6 @@ automations:
             tts_text: "The house is on fire and the cat's stuck in the dryer!"
 ```
 
-Please see the below table for new parameters to use after updating the Android app to 2022.8+:
-
-| Old Parameter | New Parameter |
-|--------|--------|
-| `channel` | `media_stream` |
-| `title` | `tts_text` |
-
 
 ### ![Android](/assets/android.svg) Text To Speech Alarm Stream Max Volume
 Alternatively using Text To Speech you can also make the notification speak as loud as it can, and then revert back to the original volume level:
@@ -147,10 +140,3 @@ automations:
             media_stream: alarm_stream_max
             tts_text: "The house is on fire and the cat's stuck in the dryer!"
 ```
-
-Please see the below table for new parameters to use after updating the Android app to 2022.8+:
-
-| Old Parameter | New Parameter |
-|--------|--------|
-| `channel` | `media_stream` |
-| `title` | `tts_text` |

--- a/docs/notifications/critical.md
+++ b/docs/notifications/critical.md
@@ -117,7 +117,6 @@ automations:
             tts_text: "The house is on fire and the cat's stuck in the dryer!"
 ```
 
-
 ### ![Android](/assets/android.svg) Text To Speech Alarm Stream Max Volume
 Alternatively using Text To Speech you can also make the notification speak as loud as it can, and then revert back to the original volume level:
 


### PR DESCRIPTION
The syntax to use for notification commands for the Android app was changed in release 2022.8, half a year ago. As most people will have had the time to migrate and to make the docs less cluttered, this PR removes the comments indicating that it has changed, keeping only the new keys in the documentation.