### PR TITLE
Remove beta labels for Android January 2023 release

### DIFF
--- a/docs/android-auto/android-auto.md
+++ b/docs/android-auto/android-auto.md
@@ -3,7 +3,7 @@ title: "Overview"
 id: "android-auto"
 ---
 
-![Android](/assets/android.svg)<span class='beta'>BETA</span><br />
+![Android](/assets/android.svg)
 
 Home Assistant has started to offer an Android Auto experience.  This will allow you to interact with various entities safely while driving your vehicle.  It will also allow you to navigate to any `zone` or `device_tracker` that has a location associated with it.
 

--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -92,7 +92,7 @@ You can change the frequency of sensor updates by navigating to [Settings](https
 | `binary_sensor.interactive` | None | Whether or not the device is in an interactive state. |
 | `binary_sensor.power_save` | None | Whether or not the device is in power saving mode. |
 | [Activity Sensors](#activity-sensors) | See Below | The current activity type, sleep confidence and sleep segment as computed by Google. Requires activity recognition permissions on supported devices. |
-| `binary_sensor.android_auto` | [See Below](#android-auto-sensor) | A binary sensor to indicate if the device is connected to Android Auto.  <span class='beta'>BETA</span> |
+| `binary_sensor.android_auto` | [See Below](#android-auto-sensor) | A binary sensor to indicate if the device is connected to Android Auto. |
 | [App Data Sensors](#app-data_sensors) | None | Sensors that show how much data was sent or received by the app. |
 | [App Importance Sensor](#app-importance-sensor) | None | The current importance of the app to determine if its in the foreground or cached. |
 | `sensor.app_memory` | [See Below](#app-memory-sensor) | Information about the memory that is available for the app. |
@@ -177,7 +177,7 @@ The attribute for the state will reflect the `confidence` rating from the [Activ
 The Sleep Confidence and Sleep Segment sensors utilize the new [Sleep API](https://developers.google.com/location-context/sleep) from Google services. Sleep Segment updates about once a day and Sleep Confidence will update about every 10 minutes. All data is provided by Google.
 
 ## Android Auto
-![Android](/assets/android.svg) <span class='beta'>BETA</span>
+![Android](/assets/android.svg)
 This sensor is used to determine if the device is connected to Android Auto.  The attributes will return the specific type of connection.
 
 
@@ -290,9 +290,7 @@ A Transmit setting toggle will start or stop the BLE transmissions. This setting
 ![Android](/assets/android.svg) <br />
 The Beacon Monitor shows scans for BLE iBeacons. The state of the sensor shows if the app is monitoring or not. All beacons in range and their distance are listed in the attributes. This sensor will update when there is a new distance measurement available.
 
-Settings are available to change scan period and interval which can be useful to preserve battery life. The setting Filter Iterations and Filter RSSI Multiplier can be adjusted to archive more stable measurements. All of these settings will affect the responsiveness of the sensor.
-
-If you are on the <span class='beta'>BETA</span> a UUID filter is also available, to limit the reported beacons to those matching (or not matching) a list of UUIDs.
+Settings are available to change scan period and interval which can be useful to preserve battery life. The setting Filter Iterations and Filter RSSI Multiplier can be adjusted to archive more stable measurements. All of these settings will affect the responsiveness of the sensor. A UUID filter is also available, to limit the reported beacons to those matching (or not matching) a list of UUIDs.
 
 A Monitor setting toggle will start or stop the scans - this setting can also be adjusted via the [notification command](../notifications/commands.md#beacon-monitor).
 

--- a/docs/integrations/android-quick-settings.md
+++ b/docs/integrations/android-quick-settings.md
@@ -7,7 +7,7 @@ id: 'android-quick-settings'
 
 The Android app offers support for quick settings [tiles](https://developer.android.com/reference/android/service/quicksettings/TileService) allowing you to quickly execute a script/scene, press (input) buttons or toggle supported domains from the notification pull down menu. You can fully customize the appearance of these tile and can reorganize them as you see fit. This feature is available on devices running Android 7.0+. To get started navigate to [Settings](https://my.home-assistant.io/redirect/config/) > Companion App > Manage Tiles.
 
-The app currently offers 12 tiles to setup (<span class='beta'>BETA</span>: up to 40 tiles). Each tile must have a label set and on Android 10 or newer can optionally have a sublabel set. After a label and entity have been selected you will be able to update the tile data. Once updated, the tile is ready to be used: edit your device's quick settings panel and drag the Home Assistant tile from the list of tiles into the active section.
+The app currently offers up to 40 tiles to setup. Each tile must have a label set and on Android 10 or newer can optionally have a sublabel set. After a label and entity have been selected you will be able to update the tile data. Once updated, the tile is ready to be used: edit your device's quick settings panel and drag the Home Assistant tile from the list of tiles into the active section.
 
 Once a tile has been added, the state, label and icon will update to reflect the entity's state and tile settings. When you select a tile you will see the tile momentarily light up as the app calls the server. If successfull the tile will go back to show the entity's state, if there is a failure the tile changes to a disabled state and an error message will be shown.
 
@@ -33,4 +33,4 @@ Optional additional settings:
 
 * Tiles will use the entity icon by default. Tap on the icon to use a different icon for the tile.
 * Vibrate when clicked can be enabled to vibrate once when the tile is clicked and twice if the service call fails.
-* <span class='beta'>BETA</span> Requires unlocked device can be enabled to only allow interacting with the tile if the device is unlocked.
+* Requires unlocked device can be enabled to only allow interacting with the tile if the device is unlocked.

--- a/docs/wear-os/sensors.md
+++ b/docs/wear-os/sensors.md
@@ -24,7 +24,7 @@ There is currently no support for sensor settings. Some sensors may not be fully
 | [Audio](../core/sensors.md#audio-sensors) | None | Several different sensors around different types of audio detection from the device. |
 | [Battery](../core/sensors.md#battery-sensors) (enabled by default) | None | Several different sensors around the state of the devices battery. |
 | `binary_sensor.bedtime_mode` | None | A sensor to reflect the state of Bedtime mode on the device. For best results enable Do Not Disturb or Interactive sensor. Only available on Wear OS 3 devices |
-| [Bluetooth Sensors](../core/sensors.md#bluetooth-sensors) | [See Attributes](../core/sensors.md#bluetooth-sensors) | Several different sensors about the state of bluetooth on the device. Sensors are also available for beacon transmitting and monitoring. <span class='beta'>BETA</span> |
+| [Bluetooth Sensors](../core/sensors.md#bluetooth-sensors) | [See Attributes](../core/sensors.md#bluetooth-sensors) | Several different sensors about the state of bluetooth on the device. Sensors are also available for beacon transmitting and monitoring. |
 | `sensor.current_time_zone` | [See Attributes](../core/sensors.md#current-time-zone-sensor) | The current time zone the device is in. |
 | [Current Version](../core/sensors.md#current-version-sensor) | None | The current installed version of the application. |
 | [Do Not Disturb](../core/sensors.md#do-not-disturb-sensor) | None | The state of do not disturb on the device. |

--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -69,7 +69,6 @@ Hint: use a [template sensor](https://www.home-assistant.io/integrations/templat
 
 ## Notifications
 
-<span class='beta'>BETA</span><br /><br />
 
 Wear OS devices will relay [notifications](../notifications/basic.md) from any app on the connected device by default, meaning the notification needs to be sent to the connected device first before it reaches the wearable. The Wear OS app allows for notifications to be sent directly to the watch itself, skipping the connected device. Not all notification features supported by the connected device will be supported by the Wear OS app due to platform limitations.
 


### PR DESCRIPTION
Remove beta labels for the release that was just submitted to the play store