### PR TITLE
Note that notification HTML formatting isn't always supported

### DIFF
--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -426,6 +426,10 @@ automation:
           title: "Cool HTML formatting"
 ```
 
+:::note Device compatibility
+Not all devices support HTML formatting in notifications, and will show basic unformatted text instead.
+:::
+
 ### Notification Icon
 
 You can set the icon for a notification by providing the `icon_url`. The URL provided must be either publicly accessible or can be a relative path (i.e. `/local/icon/icon.png`), more details can be found in [attachments](attachments.md). It is important to note that if you set the `image` then Android will not show the icon for the notification, the `image` will be shown in its place. So the `message` will be shown with the `image` and with the image as the icon.

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -427,7 +427,7 @@ automation:
 ```
 
 :::note Device compatibility
-Not all devices support HTML formatting in notifications, and will show basic unformatted text instead.
+Not all devices support HTML formatting in notifications, and some formatting may not be shown in dark mode. When not supported, notifications will show unformatted text instead.
 :::
 
 ### Notification Icon


### PR DESCRIPTION
Add a note to the docs indicating that HTML formatting in notifications is not supported on all devices / in all modes.

 - https://github.com/home-assistant/android/issues/2590
 - https://community.home-assistant.io/t/notification-message-html-formatting-color-text-doesnt-work-anymore/528531