### PR TITLE
Add more supported wear OS notification parameters

### DIFF
--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -87,6 +87,8 @@ Currently only the following parameters are supported.
 *  `title`
 *  [`notification_icon`](../notifications/basic.md#notification-status-bar-icon)
 *  [`tag`](../notifications/basic.md#replacing) (Support limited to replacing a notification only)
+*  [`channel`](../notifications/basic.md#notification-channels)
+*  [`vibrationPattern`](../notifications/basic.md#notification-vibration-pattern)
 
 Example:
 

--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -85,10 +85,10 @@ Currently only the following parameters are supported.
 
 *  `message`
 *  `title`
-*  [`notification_icon`](../notifications/basic.md#notification-status-bar-icon)
+*  [`notification_icon`](../notifications/basic.md#notification-status-bar-icon) (Not all devices will show the icon)
 *  [`tag`](../notifications/basic.md#replacing) (Support limited to replacing a notification only)
 *  [`channel`](../notifications/basic.md#notification-channels)
-*  [`vibrationPattern`](../notifications/basic.md#notification-vibration-pattern)
+*  [`vibrationPattern`](../notifications/basic.md#notification-vibration-pattern) (May need to set the vibration if your device does not vibrate by default, the pattern may not be respected based on the device)
 
 Example:
 

--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -83,11 +83,11 @@ Wear OS devices will relay [notifications](../notifications/basic.md) from any a
 
 Currently only the following parameters are supported.
 
+*  [`channel`](../notifications/basic.md#notification-channels)
 *  `message`
-*  `title`
 *  [`notification_icon`](../notifications/basic.md#notification-status-bar-icon) (Not all devices will show the icon)
 *  [`tag`](../notifications/basic.md#replacing) (Support limited to replacing a notification only)
-*  [`channel`](../notifications/basic.md#notification-channels)
+*  `title`
 *  [`vibrationPattern`](../notifications/basic.md#notification-vibration-pattern) (May need to set the vibration if your device does not vibrate by default, the pattern may not be respected based on the device)
 
 Example:


### PR DESCRIPTION
Channel and vibration pattern do work, LED color may work but difficult if not impossible to test as I do not think any watches have a LED to control :)

~~Alarm stream may also work but is also not yet tested.~~ Alarm stream does not seem to work on Pixel Watch it most likely does not work on other watches.