### PR TITLE
Android multiserver docs

### DIFF
--- a/docs/core/location.md
+++ b/docs/core/location.md
@@ -67,10 +67,10 @@ If you want to know more about the specifics of these attributes, please refer t
 
 ## Manage location tracking level
 
-When using core 2022.2 with ![iOS](/assets/iOS.svg) 2022.2 or ![Android](/assets/android.svg) 2022.11 or later, you can configure how locations are sent on a per-server basis in the Companion App Settings:
+When using core 2022.2 or later, you can configure how locations are sent in the Companion App Settings:
 
- - ![iOS](/assets/iOS.svg) Open the server's settings and change the Location Sent setting under Privacy.
- - ![Android](/assets/android.svg) Go to Manage Sensors > Background Location and change the Location Sent setting.
+ - ![iOS](/assets/iOS.svg) The setting can be managed on a per-server basis. Open the server's settings and change the Location Sent setting under Privacy.
+ - ![Android](/assets/android.svg) The setting applies to all connected servers. Go to Manage Sensors > Background Location and change the Location Sent setting.
 
 Options available:
 
@@ -125,12 +125,6 @@ Restart Home Assistant and then the iOS app. It will then begin using iBeacons _
 [apple-energy-guide]: https://developer.apple.com/library/content/documentation/Performance/Conceptual/EnergyGuide-iOS/LocationBestPractices.html#//apple_ref/doc/uid/TP40015243-CH24-SW4
 [apple-location-programming-guide]: https://developer.apple.com/library/content/documentation/UserExperience/Conceptual/LocationAwarenessPG/CoreLocation/CoreLocation.html#//apple_ref/doc/uid/TP40009497-CH2-SW9
 [stackoverflow]: http://stackoverflow.com/a/13331625/486182
-
-## Multi-server location updates
-
-![iOS](/assets/iOS.svg)
-
-If multiple servers are connected to an iOS/mac app, all available servers will receive the the same location updates.
 
 ## Sending an intent
 

--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -5,19 +5,20 @@ id: 'sensors'
 
 Along with providing [location services](location.md), the companion app also adds several additional sensors to Home Assistant. If you don't want the `device_tracker` entity but still want sensors to update then just disable the entity in the [entity registry](https://www.home-assistant.io/integrations/config/#entity-registry) to stop location updates and keep sensor updates.
 
-The sensors provided by the companion app are:
+The sensors provided by the companion app depend on which app you're using, see the lists below.
 
-## iOS & macOS Sensors
+## Multi-Server Support
 
-### Multi-Server Support
+If multiple servers are connected to the companion app, currently the sensor settings will be common for all connected servers.
 
-If multiple servers are connected to an iOS or macOS app, currently the sensor settings will be common for all connected servers.
-
-![iOS](/assets/iOS.svg)
- In iOS-2022.2 or later, you can configure whether sensors are sent on a per-server basis. In App Configuration, open the server's settings and change Sensors Sent setting under Privacy. Options available:
+![iOS](/assets/iOS.svg) You can configure whether sensors are sent on a per-server basis. In [Settings](https://my.home-assistant.io/redirect/config/) > Companion App, open the server's settings and change Sensors Sent setting under Privacy. Options available:
 
 - **All** sends all enabled sensors.
 - **None** does not send any sensors.
+
+![Android](/assets/android.svg) <span class='beta'>BETA</span> Enabled sensors are sent to all connected servers.
+
+## iOS & macOS Sensors
 
 ### When Sensors Update
 

--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -45,13 +45,13 @@ If you have difficulties completing setting up the app, please see the [troubles
 
 ## Adding Additional Servers
 
-![iOS](/assets/iOS.svg)<span class="beta">BETA</span>
+![iOS](/assets/iOS.svg) or ![Android](/assets/android.svg) <span class="beta">BETA</span>
 
 :::note
-Requires Home Assistant ios-2021.12 and core-2021.10.
+Requires Home Assistant 2021.10 or newer.
 :::
 
-Once you have set up your first server, you can add additional Home Assistant instances via the App Configuration page and the "Add Server" option. Servers on the same local network as your device will be discovered and listed automatically or you can manually enter the address in the same way as setting up the first server.
+Once you have set up your first server, you can add additional Home Assistant instances via [Settings](https://my.home-assistant.io/redirect/config/) > Companion App and the "Add Server" option. Servers on the same local network as your device will be discovered and listed automatically or you can manually enter the address in the same way as setting up the first server.
 
 ## TLS Client Authentication
 

--- a/docs/integrations/url-handler.md
+++ b/docs/integrations/url-handler.md
@@ -9,7 +9,10 @@ Query parameters are passed as a dictionary in the call.
 
 :::info
 ![iOS](/assets/iOS.svg)<br />
-If multiple servers are connected to an iOS or mac app, you will be prompted to select a server when handling a `navigate` link, `call_service`, or `fire_event`  links will be handled using the first server in the list.
+If multiple servers are connected to an iOS or Mac app, you will be prompted to select a server when handling a `navigate` link, `call_service`, or `fire_event`  links will be handled using the first server in the list.
+
+![Android](/assets/android.svg) <span class='beta'>BETA</span><br />
+If multiple servers are connected to an Android app, `navigate` links will be handled using the most recently used server in the list.
 :::
 
 ## Navigate


### PR DESCRIPTION
Documentation PR for home-assistant/android#3332. Trying to align it with iOS, removed version numbers where irrelevant (always assuming the app version is current). 