### PR TITLE
Add a note for multi server considerations when using group or tag in notifications

### DIFF
--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -106,6 +106,10 @@ automation:
             clickAction: "/lovelace/cameras"
 ```
 
+:::info
+The below sections for [Grouping](#grouping), [Replacing](#replacing) and [Clearing](#clearing) do not take multiple servers into account. If you use the same text for `group` or `tag` you should expect to see the same behavior regardless of which server sent the notification. You may consider adding the server name to the current text to make the behavior server specific.
+:::
+
 ### Grouping
 
 Combine notifications together visually.


### PR DESCRIPTION
A quick note for users to consider things in case they unexpectedly remove/change/group a notification to/from another server.

We have not seen any complaints but good to let users know what to expect