### PR TITLE
Add clarification to the use of tags on persistent notifications

### DIFF
--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -379,7 +379,7 @@ automation:
           message: "Motion detected"
           data:
             persistent: true # Set to true to create a persistent notification
-            tag: "persistent" # Tag is required for the persistent notification
+            tag: "motion" # A tag is required for the persistent notification, it can be any value
 ```
 
 To remove the persistent notification we send `clear_notification` to the `tag` that we defined.
@@ -394,7 +394,7 @@ automation:
         data:
           message: "clear_notification"
           data:
-            tag: "persistent" # The tag for the persistent notification you wish to clear
+            tag: "motion" # The tag for the persistent notification you wish to clear
 ```
 
 ### Notification Timeout


### PR DESCRIPTION
These changes update the documentation to make clear that while a tag must be defined, it does not have to be named "persistent". Based on the verbiage of "persistent" as the tag name, it may seem to some that the tag must have the specific name "persistent". To clear up any misconception, I changed the name of the tag from persistent to motion and clarified that the tag can be any value