### PR TITLE
Add a note about persistent notification behavior starting in Android 14

### DIFF
--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -364,9 +364,6 @@ automation:
 
 ### Persistent Notification
 
-:::info
-Starting in [Android 14](https://developer.android.com/about/versions/14/behavior-changes-all#non-dismissable-notifications) persistent notifications will be dismissable by the user except when the phone is locked or user has selected "Clear All" button.
-:::
 
 Persistent notifications are notifications that cannot be dismissed by swiping away. These are useful if you have something important like an alarm being triggered. In order to use this property you must set the `tag` property as well. The `persistent` property only takes boolean (`true/false`) values, with `false` being the default. The persistent notification will still be dismissed once selected, to avoid this use `sticky: true` so the notification stays.
 
@@ -385,6 +382,10 @@ automation:
             persistent: true # Set to true to create a persistent notification
             tag: "motion" # A tag is required for the persistent notification, it can be any value
 ```
+
+:::info
+Starting in [Android 14](https://developer.android.com/about/versions/14/behavior-changes-all#non-dismissable-notifications) persistent notifications will be dismissable by you except when the device is locked or you have selected the "Clear All" button.
+:::
 
 To remove the persistent notification we send `clear_notification` to the `tag` that we defined.
 

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -364,7 +364,6 @@ automation:
 
 ### Persistent Notification
 
-
 Persistent notifications are notifications that cannot be dismissed by swiping away. These are useful if you have something important like an alarm being triggered. In order to use this property you must set the `tag` property as well. The `persistent` property only takes boolean (`true/false`) values, with `false` being the default. The persistent notification will still be dismissed once selected, to avoid this use `sticky: true` so the notification stays.
 
 In the example below we will create a notification and then later on we will remove it.

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -364,6 +364,10 @@ automation:
 
 ### Persistent Notification
 
+:::info
+Starting in [Android 14](https://developer.android.com/about/versions/14/behavior-changes-all#non-dismissable-notifications) persistent notifications will be dismissable by the user except when the phone is locked or user has selected "Clear All" button.
+:::
+
 Persistent notifications are notifications that cannot be dismissed by swiping away. These are useful if you have something important like an alarm being triggered. In order to use this property you must set the `tag` property as well. The `persistent` property only takes boolean (`true/false`) values, with `false` being the default. The persistent notification will still be dismissed once selected, to avoid this use `sticky: true` so the notification stays.
 
 In the example below we will create a notification and then later on we will remove it.

--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -384,7 +384,7 @@ automation:
 ```
 
 :::info
-Starting in [Android 14](https://developer.android.com/about/versions/14/behavior-changes-all#non-dismissable-notifications) persistent notifications will be dismissable by you except when the device is locked or you have selected the "Clear All" button.
+Starting in [Android 14](https://developer.android.com/about/versions/14/behavior-changes-all#non-dismissable-notifications) persistent notifications will be dismissable except when the device is locked or the "Clear All" button was selected.
 :::
 
 To remove the persistent notification we send `clear_notification` to the `tag` that we defined.


### PR DESCRIPTION
We have a upcoming behavior change to one of our parameters so need to inform the user about this.

Ref: https://github.com/home-assistant/android/issues/3655

Actual docs: https://developer.android.com/about/versions/14/behavior-changes-all#non-dismissable-notifications