### PR TITLE
Mention entity limit in android auto

### DIFF
--- a/docs/android-auto/android-auto.md
+++ b/docs/android-auto/android-auto.md
@@ -25,6 +25,10 @@ In order to use this integration you will need a phone as well as a vehicle with
 - `script`
 - `switch`
 
+:::note
+The amount of entities shown will depend on the imposed limit set by the vehicle.
+:::
+
 ### Notifications
 
 By default Home Assistant notifications do not show up in the Android Auto interface. To show Home Assistant notifications in Android Auto, add [`car_ui: true` to the notification data](../notifications/basic.md#android-auto-visibility). Notifications will now show up on your phone _and_ in Android Auto. Opening the notification from Android Auto will open the driving interface for Home Assistant.


### PR DESCRIPTION
This does not require a beta label as the limit is already imposed however we discovered this limit while working on https://github.com/home-assistant/android/pull/3687 as the app can still crash if we add too many.