### PR TITLE
Update Wear OS docs for multiple Shortcuts tiles support

### DIFF
--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -48,7 +48,7 @@ The settings screen can be found at the bottom of the home screen. This is where
 ## Tiles
 
 * The Shortcuts tile shows up to 7 shortcuts, which can be chosen from the settings section in the Wear OS app. You will be able to select the same set of entities you can access from the home screen. 
-<span class='beta'>BETA</span> Starting from Wear OS 3, any number of separately configurable tiles can be added, only limited by Wear OS's limit for the max number of total tiles.
+<span class='beta'>BETA</span> Starting from Wear OS 3, any number of separately configurable tiles can be added, only limited by Wear OS's limit for the total number of tiles.
 * The Template tile shows a rendered template. The template can only be set from the android companion app. Note: it is not possible to scroll in a tile, the template should fit on the watch screen.
 * The Assist tile allows you to send a voice transcription to the [`conversation`](https://www.home-assistant.io/integrations/conversation/) integration to process. The results are then shown on the screen. This feature requires Home Assistant Core 2023.1 and also the `conversation` integration enabled.
 

--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -47,7 +47,8 @@ The settings screen can be found at the bottom of the home screen. This is where
 
 ## Tiles
 
-* The Shortcuts tile shows up to 7 shortcuts, which can be chosen from the settings section in the Wear OS app. You will be able to select the same set of entities you can access from the home screen.
+* The Shortcuts tile shows up to 7 shortcuts, which can be chosen from the settings section in the Wear OS app. You will be able to select the same set of entities you can access from the home screen. 
+<span class='beta'>BETA</span> Starting from Wear OS 3, any number of separately configurable tiles can be added, only limited by Wear OS's limit for the max number of total tiles.
 * The Template tile shows a rendered template. The template can only be set from the android companion app. Note: it is not possible to scroll in a tile, the template should fit on the watch screen.
 * The Assist tile allows you to send a voice transcription to the [`conversation`](https://www.home-assistant.io/integrations/conversation/) integration to process. The results are then shown on the screen. This feature requires Home Assistant Core 2023.1 and also the `conversation` integration enabled.
 


### PR DESCRIPTION
Describe a new beta feature where any number of Shortcuts tiles can be added

PR for the feature: https://github.com/home-assistant/android/pull/3697