### PR TITLE
Fix conflicting URL handler information for Android in the docs

### DIFF
--- a/docs/integrations/url-handler.md
+++ b/docs/integrations/url-handler.md
@@ -8,11 +8,7 @@ Home Assistant supports opening from other apps via URL.
 Query parameters are passed as a dictionary in the call.
 
 :::info
-![iOS](/assets/iOS.svg) and ![Android](/assets/android.svg)
-If multiple servers are connected to an app, you will be prompted to select a server when handling a `navigate` link, `call_service`, or `fire_event`  links will be handled using the first server in the list.
-
-![Android](/assets/android.svg)<br />
-If multiple servers are connected to an Android app, `navigate` links will be handled using the most recently used server in the list.
+If multiple servers are connected to an app, you will be prompted to select a server when handling a `navigate` link. `call_service` and `fire_event`  links will be handled using the first server in the list.
 :::
 
 ## Navigate


### PR DESCRIPTION
The Android release PR only removed the beta tag for the new URL handler behavior (matching iOS), but did not remove the information relating to the old URL handler behavior for multiserver.