### PR TITLE
Update documentation about TLS CCA on Android

### DIFF
--- a/docs/getting_started/index.md
+++ b/docs/getting_started/index.md
@@ -59,8 +59,10 @@ Once you have set up your first server, you can add additional Home Assistant in
 
 ## TLS Client Authentication
 
-![Android](/assets/android.svg) excluding Wear OS
+![Android](/assets/android.svg) (<span class='beta'>BETA</span> Wear OS)
 
 If your Home Assistant requires TLS Client Authentication (because it is behind a reverse proxy configured to perform TLS Client Authentication), the app will ask for a certificate. If no matching certificate is installed or supplied, you might see an error or a blank screen depending on your setup.
 
-Please refer to your device and Android version documentation to install the certificate. Make sure to install the certificate as a "VPN & app user certificate". An example for Pixel phones is available here: [Add & remove certificates](https://support.google.com/pixelphone/answer/2844832?hl=en). 
+Please refer to your device and Android version documentation to install the certificate. Make sure to install the certificate as a "VPN & app user certificate". An example for Pixel phones is available here: [Add & remove certificates](https://support.google.com/pixelphone/answer/2844832?hl=en).
+
+<span class='beta'>BETA</span> Wear OS does not support authentication with installed certificates. The app cannot transfer the certificate to the Wear OS app automatically, therefore you are asked to provide a certificate during the Wear OS app onboarding.

--- a/docs/troubleshooting/networking.md
+++ b/docs/troubleshooting/networking.md
@@ -81,3 +81,5 @@ Note: If you don't use the NGINX Home Assistant add-on but instead roll your own
 
 If your Home Assistant requires TLS Client Authentication (because it is behind a reverse proxy configured to perform TLS Client Authentication), the app will ask for a certificate.
 Please refer to your device and Android version documentation to install the certificate, an example for Pixel phones is available here [Add & remove certificates](https://support.google.com/pixelphone/answer/2844832?hl=en).
+
+<span class='beta'>BETA</span> Wear OS does not support authentication with installed certificates. The app cannot transfer the certificate to the Wear OS app automatically, therefore you are asked to provide a certificate during the Wear OS app onboarding. If a new certificate is required, you have to start the onboarding process again by logging out from the Wear OS app.


### PR DESCRIPTION
This updates documentation about TLS Client Certificate Authentication changes in https://github.com/home-assistant/android/pull/3924.