### PR TITLE
Add clear_notification to Wear OS notification commands

### DIFF
--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -117,6 +117,7 @@ The Wear OS app has basic support for [notification commands](../notifications/c
 *  [Beacon Monitor](../notifications/commands.md#beacon-monitor)
 *  [Stop TTS](../notifications/commands.md#stop-tts)
 *  [Update Sensors](../notifications/commands.md#update-sensors)
+*  <span class='beta'>BETA 2023.10.3+</span> [Clearing notifications](../notifications/basic.md#clearing)
 
 ### Text To Speech Notifications
 

--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -115,9 +115,9 @@ The Wear OS app has basic support for [notification commands](../notifications/c
 
 *  [BLE Transmitter](../notifications/commands.md#ble-beacon-transmitter)
 *  [Beacon Monitor](../notifications/commands.md#beacon-monitor)
+*  [Clearing notifications](../notifications/basic.md#clearing) <span class='beta'>BETA 2023.10.3+</span>
 *  [Stop TTS](../notifications/commands.md#stop-tts)
 *  [Update Sensors](../notifications/commands.md#update-sensors)
-*  <span class='beta'>BETA 2023.10.3+</span> [Clearing notifications](../notifications/basic.md#clearing)
 
 ### Text To Speech Notifications
 

--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -115,7 +115,7 @@ The Wear OS app has basic support for [notification commands](../notifications/c
 
 *  [BLE Transmitter](../notifications/commands.md#ble-beacon-transmitter)
 *  [Beacon Monitor](../notifications/commands.md#beacon-monitor)
-*  [Clearing notifications](../notifications/basic.md#clearing) <span class='beta'>BETA 2023.10.3+</span>
+*  [Clearing notifications](../notifications/basic.md#clearing) <span class='beta'>BETA</span>
 *  [Stop TTS](../notifications/commands.md#stop-tts)
 *  [Update Sensors](../notifications/commands.md#update-sensors)
 


### PR DESCRIPTION
Documentation PR for home-assistant/android#3956

I considered mentioning [the expected beta release](https://github.com/home-assistant/companion.home-assistant/pull/998#pullrequestreview-1672790397) this is in instead of just 'beta', but in the end you still have to clean up as Home Assistant documentation is expected to be for the current version / the docs would have app version references everywhere.