### PR TITLE
Drop pre-iOS 13 notes from actionable.md

### DIFF
--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -361,17 +361,3 @@ automation:
 ```
 
 The above is the minimum necessary to migrate. You can also rewrite your automations to use `wait_for_trigger` like previous examples, though this is more work and not strictly necessary.
-
-## Compatibility with different devices
-
-![iOS](/assets/iOS.svg)Specific
-
-### iOS 13 and later
-
-* All devices support notification expanding by performing a right to left swipe and pressing 'View' in the lock screen or pressing and holding, but on 3D Touch-enabled devices you may still need to apply some force to do it. If you're not in the lock screen, you can also pull the notification down to expand it.
-
-### Prior to iOS 13
-
-*   For devices that support 3D Touch - a firm press on the notification will expand it, showing the action buttons underneath. Supported devices include the iPhone 6S, iPhone 6S Plus, iPhone 7, iPhone 7 Plus, iPhone 8, iPhone 8 Plus, iPhone X, iPhone XS and iPhone XS Max. If not in lock screen, you can also pull the notification down to expand it.
-
-*   For devices that do not support "3D Touch" (such as the iPhone 6 and below, iPhone SE, iPhone XR and iPads), you perform a left to right swipe on the notification, then tap on the 'View' button. This will expand the notification and show the relevant action buttons underneath. If not in lock screen, you need to pull the notification down to expand it.


### PR DESCRIPTION
The companion app [no longer supports iOS versions before iOS 15](https://www.home-assistant.io/blog/2023/12/27/companion-app-for-ios-202312-lets-go/), so we can safely remove this.