### PR TITLE
Add Tile status entity

### DIFF
--- a/docs/integrations/android-quick-settings.md
+++ b/docs/integrations/android-quick-settings.md
@@ -29,6 +29,10 @@ The following domains are supported:
 *  `script` Turn on script
 *  `switch` Toggle
 
+State Display via Binary Sensor:
+
+To address entities that perform actions (such as toggling or pressing) without changing their state, tiles can now be linked to a `binary_sensor`. This sensor provides visual feedback on the tile, representing the actual state of the entity. This feature is ideal for entities like switches controlling mechanisms (e.g., a garage door opener) where the state (open or closed) needs to be monitored separately.
+
 Optional additional settings:
 
 * Tiles will use the entity icon by default. Tap on the icon to use a different icon for the tile.


### PR DESCRIPTION
I'm adding a new functionality (modification of the Android Tile) to the Home Assistant Android application. I want to control the garage door as quickly as possible. However, the switch that controls it does not correspond to the state but only opens or closes the garage door (it turns on for 1 second and then turns off). I have another entity for the state, but its state cannot be displayed. So, I added an option that allows the user to display (overwrite) the state, and I have only allowed binary_sensor.