### PR TITLE
Update supported Complication types within apple-watch.md

### DIFF
--- a/docs/apple-watch/apple-watch.md
+++ b/docs/apple-watch/apple-watch.md
@@ -17,6 +17,10 @@ The Apple Watch has a variety of Faces and Complications. It's useful to consult
 - Ring and Gauge, which appear circular lines. An open variant appears as a complete circle and a closed variant has concrete start and end locations in the icon. Rings and Gauges require numeric values between `0.0` (empty) and `1.0` (full) and also support [templates](https://www.home-assistant.io/docs/configuration/templating/).
 - Images can be selected from the [Material Design Icons](http://materialdesignicons.com) choices supported by the app. 
 
+:::info Supported Complication types
+As of watchOS 9, several (legacy) Complication types are no longer supported by Apple. The following Complication types can be used for watchOS 9 and higher: Graphic Circular, Graphic Corner, Graphic Rectangular & Modular Large. Further details on the different types can be found in the [Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/components/system-experiences/complications/).
+:::
+
 :::note app version 
 Ring and Gauge features do not work in app releases prior to 2020.7.
 :::


### PR DESCRIPTION
Added a section to specify which Complication types are supported with watchOS 9.0 and higher.