### PR TITLE
Mention Android alternative on notification sounds page

### DIFF
--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -242,7 +242,7 @@ automation:
 
 ### Notification Channels
 
-Notification channels allows users to separate their notifications easily (i.e. alarm vs laundry) so they can customize aspects like what type of sound is made and a lot of other device specific features. Devices running Android 8.0+ are able to create and manage notification channels on the fly using automations. Once a channel is created you can navigate to your notification settings and you will find the newly created channel, from there you can customize the behavior based on what your device allows.
+Notification channels (on some devices: _notification categories_) allow you to separate your notifications easily (i.e. alarm vs laundry) and customize aspects like the notification sound and a lot of other device specific features. Devices running Android 8.0+ are able to create and manage notification channels on the fly using automations. Once a channel is created you can navigate to your notification settings and you will find the newly created channel, from there you can customize the behavior based on what your device allows.
 
 #### Creating a channel
 

--- a/docs/notifications/sounds.md
+++ b/docs/notifications/sounds.md
@@ -5,7 +5,7 @@ id: "notification-sounds"
 
 Adding a custom sound to a notification allows you to easily identify the notification without even looking at your device. How to set a custom sound, depends on the operating system.
 
- - ![Android](/assets/android.svg) On Android, notification sounds are linked to [notification channels/categories](../basic.md#notification-channels). On your device, edit the channel settings to change the notification sound to another system sound or choose your own.
+ - ![Android](/assets/android.svg) On Android, notification sounds are linked to [notification channels/categories](basic.md#notification-channels). On your device, edit the channel settings to change the notification sound to another system sound or choose your own.
  - ![iOS](/assets/iOS.svg) Home Assistant for iOS comes with some notification sounds pre-installed, but you can also upload your own.
 
 :::info

--- a/docs/notifications/sounds.md
+++ b/docs/notifications/sounds.md
@@ -3,8 +3,14 @@ title: "Sounds"
 id: "notification-sounds"
 ---
 
-![iOS](/assets/iOS.svg)<br />
-Adding a custom sound to a notification allows you to easily identify the notification without even looking at your device. Home Assistant for iOS comes with some notification sounds pre-installed, but you can also upload your own.
+Adding a custom sound to a notification allows you to easily identify the notification without even looking at your device. How to set a custom sound, depends on the operating system.
+
+ - ![Android](/assets/android.svg) On Android, notification sounds are linked to [notification channels/categories](../basic.md#notification-channels). On your device, edit the channel settings to change the notification sound to another system sound or choose your own.
+ - ![iOS](/assets/iOS.svg) Home Assistant for iOS comes with some notification sounds pre-installed, but you can also upload your own.
+
+:::info
+The information below describes using custom notification sounds on iOS. For Android, go to [Settings](https://my.home-assistant.io/redirect/config/) > Companion app > Notification channels to change the sounds and refer to your device settings.
+:::
 
 Here is an example notification that uses one of the pre-installed sounds.
 


### PR DESCRIPTION
Fixes #1040:

 - Rewrite the opening of the notification sounds page to mention how this can be achieved on Android
 - Add that on some devices notification channels may be called [notification categories](https://9to5google.com/2024/01/31/samsung-android-notifications-categories-channels/)
 - Update first sentence of notification channels info to use 'you' instead of 'the user'/'their', matching other sentences in the same paragraph