### PR TITLE
Document battery power in volts on Android

### DIFF
--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -267,8 +267,6 @@ The battery sensors listed below describe the state of the battery for a few dif
 | `charger_type` | The type of charger being used on the device |
 | `is_charging` | Whether or not the device is actively charging |
 
-![Android](/assets/android.svg)
-
 :::info
 The `battery_power` sensor converts the values returned by the device to amperes and volts. However, some devices do not follow Android documentation and may return values in a different unit, which results in the sensor being incorrect. For these devices you may need to adjust the sensor setting for 'Battery current divisor' to properly convert the `current` to amperes (and when using <span class='beta'>BETA</span>: and for 'Battery voltage divisor' to properly convert the `voltage` to volts).
 

--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -269,7 +269,13 @@ The battery sensors listed below describe the state of the battery for a few dif
 
 ![Android](/assets/android.svg)
 
-The `battery_power` sensor attempts to convert microamperes to amperes however some devices do not follow Android documentation and may return a different unit. For these devices you may need to adjust the sensor setting for `Battery Current Divisor` to properly convert the `current` to amperes.
+:::info
+The `battery_power` sensor is configured by default to convert the values returned by the device to amperes and volts. However, some devices do not follow Android documentation and may return values in a different unit, which results in the sensor being incorrect. For these devices you may need to adjust the sensor setting for 'Battery current divisor' to properly convert the `current` to amperes (and when using <span class='beta'>BETA</span>: and for 'Battery voltage divisor' to properly convert the `voltage` to volts).
+
+Common values for the Battery current divisor: 1000000 (default, microamperes), 1000 (milliamperes), 1000000000 (nanoamperes)
+
+Common values for the Battery voltage divisor: 1000 (default, millivolts), 1 (no conversion required, volts)
+:::
 
 ## Bluetooth Sensors
 ![Android](/assets/android.svg)<br />

--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -270,7 +270,7 @@ The battery sensors listed below describe the state of the battery for a few dif
 ![Android](/assets/android.svg)
 
 :::info
-The `battery_power` sensor is configured by default to convert the values returned by the device to amperes and volts. However, some devices do not follow Android documentation and may return values in a different unit, which results in the sensor being incorrect. For these devices you may need to adjust the sensor setting for 'Battery current divisor' to properly convert the `current` to amperes (and when using <span class='beta'>BETA</span>: and for 'Battery voltage divisor' to properly convert the `voltage` to volts).
+The `battery_power` sensor converts the values returned by the device to amperes and volts. However, some devices do not follow Android documentation and may return values in a different unit, which results in the sensor being incorrect. For these devices you may need to adjust the sensor setting for 'Battery current divisor' to properly convert the `current` to amperes (and when using <span class='beta'>BETA</span>: and for 'Battery voltage divisor' to properly convert the `voltage` to volts).
 
 Common values for the Battery current divisor: 1000000 (default, microamperes), 1000 (milliamperes), 1000000000 (nanoamperes)
 


### PR DESCRIPTION
Documentation PR for home-assistant/android#4299, and also adding common values to make it easier for readers to figure out what magic number they might need