### PR TITLE
Fix notification image attachment example

### DIFF
--- a/docs/notifications/attachments.md
+++ b/docs/notifications/attachments.md
@@ -93,7 +93,7 @@ automation:
           message: "Something happened at home!"
           data:
             # an example of an absolute url
-            image: "https://github.com/home-assistant/assets/blob/master/logo/logo.png?raw=true"
+            image: "https://www.home-assistant.io/images/default-social.png"
             # example of a relative url
             image: "/media/local/image.png"
             # the same works for video


### PR DESCRIPTION
Provide a working link as an example for the notification image attachment, as the existing example no longer works. This image has existed for 8 years so should be safe.

([via @dshokouhi ](https://github.com/home-assistant/android/issues/4342#issuecomment-2051814514)