### PR TITLE
fix missing macOS table header

### DIFF
--- a/docs/core/index.md
+++ b/docs/core/index.md
@@ -205,6 +205,7 @@ Not all features are supported by Android at the moment but eventually most feat
       <th><img alt="Android" src="/assets/android.svg" /> Full</th>
       <th><img alt="Android" src="/assets/android.svg" /> Minimal</th>
       <th><img alt="iOS" src="/assets/iOS.svg" /></th>
+      <th><img alt="macOS" src="/assets/macOS.svg" /></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
The table header is missing for macOS in the Notifications group.  This puts it in there so the table is complete.