### PR TITLE
Add android app launching links examples

### DIFF
--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -157,6 +157,13 @@ You can send a specific [deep link](https://developer.android.com/training/app-l
   uri: "deep-link://example://link/to/content"
 ```
 
+You can also use this for application-launching URLs. For example, to make a telephone call:
+```yaml
+- action: "URI"
+  title: "Deep Link"
+  uri: "deep-link://tel:2125551212"
+```
+
 #### ![iOS](/assets/iOS.svg) specific
 
 You can also use application-launching URLs. For example, to make a telephone call:

--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -160,7 +160,7 @@ You can send a specific [deep link](https://developer.android.com/training/app-l
 You can also use this for application-launching URLs. For example, to make a telephone call:
 ```yaml
 - action: "URI"
-  title: "Deep Link"
+  title: "Call Pizza Hut"
   uri: "deep-link://tel:2125551212"
 ```
 

--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -151,13 +151,8 @@ You can also use an [intent scheme URI](https://developer.chrome.com/docs/multid
 
 You can send a specific [deep link](https://developer.android.com/training/app-links#deep-links) to an app by using `deep-link://<deep_link>` where `<deep_link>` is the actual deep link you wish to send.
 
-```yaml
-- action: "URI"
-  title: "Deep Link"
-  uri: "deep-link://example://link/to/content"
-```
+For example, to make a telephone call:
 
-You can also use this for application-launching URLs. For example, to make a telephone call:
 ```yaml
 - action: "URI"
   title: "Call Pizza Hut"


### PR DESCRIPTION
The documentation wasn't clear on how to dial a phone number (or mailto, etc.) on Android, it seemed it was only possible on iOS. I found how to do it and think it could be useful to somebody else