### PR TITLE
Update docs with corrected dashboard URLs

### DIFF
--- a/docs/integrations/url-handler.md
+++ b/docs/integrations/url-handler.md
@@ -12,9 +12,12 @@ If multiple servers are connected to an app, you will be prompted to select a se
 :::
 
 ## Navigate
-This allows you to update the frontend page location via a deeplink.
+This allows you to update the frontend page location via a deeplink. To build a deeplink, follow these steps:
 
-For example: if you had a dashboard at `/webcams` you can use `homeassistant://navigate/webcams` to launch the app there. Similarly, you can navigate to a subview named `example` under your `/webcams` dashboard using `homeassistant://navigate/webcams/example`.
+1. Navigate to the link you'd like to deeplink to in the web app, e.g. `http://homeassistant.local:8123/dashboard-mobile/my-subview`
+2. Copy the path portion of the URL, in this example that would be `/dashboard-mobile/my-subview`
+3. Craft your URL by starting with `homeassistant://navigate` and adding the path, e.g. `homeassistant://navigate/dashboard-mobile/my-subview`
+4. Optional: if you have multiple servers and want to link to one directly, add `?server=My%20Server%20Name` to the end (note that %20 is how you represent a space in a URL, commonly called URL encoding), e.g. `homeassistant://navigate/dashboard-mobile/my-subview?server=My%20House`
 
 #### Define server
 ![iOS](/assets/iOS.svg) <span class='beta'>BETA</span><br />

--- a/docs/integrations/url-handler.md
+++ b/docs/integrations/url-handler.md
@@ -14,13 +14,13 @@ If multiple servers are connected to an app, you will be prompted to select a se
 ## Navigate
 This allows you to update the frontend page location via a deeplink.
 
-For example: if you had a dashboard at `/lovelace/webcams` you can use `homeassistant://navigate/lovelace/webcams` to launch the app there.
+For example: if you had a dashboard at `/webcams` you can use `homeassistant://navigate/webcams` to launch the app there. Similarly, you can navigate to a subview named `example` under your `/webcams` dashboard using `homeassistant://navigate/webcams/example`.
 
 #### Define server
 ![iOS](/assets/iOS.svg) <span class='beta'>BETA</span><br />
 By default the App will ask which server you want to navigate to in case you have multiple servers.
 To define which server you want to navigate to, use the query param `?server=` like the example below:<br /><br />
-`homeassistant://navigate/lovelace/webcams?server=My%20home` when your server name is `My Home`, or use `?server=default` if you want to navigate to the first server available.
+`homeassistant://navigate/webcams?server=My%20home` when your server name is `My Home`, or use `?server=default` if you want to navigate to the first server available.
 
 ## Call service
 ![iOS](/assets/iOS.svg)<br />

--- a/docs/integrations/url-handler.md
+++ b/docs/integrations/url-handler.md
@@ -17,7 +17,7 @@ This allows you to update the frontend page location via a deeplink. To build a 
 1. Navigate to the link you'd like to deeplink to in the web app, e.g. `http://homeassistant.local:8123/dashboard-mobile/my-subview`
 2. Copy the path portion of the URL, in this example that would be `/dashboard-mobile/my-subview`
 3. Craft your URL by starting with `homeassistant://navigate` and adding the path, e.g. `homeassistant://navigate/dashboard-mobile/my-subview`
-4. Optional: if you have multiple servers and want to link to one directly, add `?server=My%20Server%20Name` to the end (note that %20 is how you represent a space in a URL, commonly called URL encoding), e.g. `homeassistant://navigate/dashboard-mobile/my-subview?server=My%20House`
+4. ![iOS](/assets/iOS.svg) Optional (iOS only): if you have multiple servers and want to link to one directly, add `?server=My%20Server%20Name` to the end (note that %20 is how you represent a space in a URL, commonly called URL encoding), e.g. `homeassistant://navigate/dashboard-mobile/my-subview?server=My%20House`
 
 #### Define server
 ![iOS](/assets/iOS.svg) <span class='beta'>BETA</span><br />

--- a/docs/integrations/url-handler.md
+++ b/docs/integrations/url-handler.md
@@ -17,9 +17,8 @@ This allows you to update the frontend page location via a deeplink. To build a 
 1. Navigate to the link you'd like to deeplink to in the web app, e.g. `http://homeassistant.local:8123/dashboard-mobile/my-subview`
 2. Copy the path portion of the URL, in this example that would be `/dashboard-mobile/my-subview`
 3. Craft your URL by starting with `homeassistant://navigate` and adding the path, e.g. `homeassistant://navigate/dashboard-mobile/my-subview`
-4. ![iOS](/assets/iOS.svg) Optional (iOS only): if you have multiple servers and want to link to one directly, add `?server=My%20Server%20Name` to the end (note that %20 is how you represent a space in a URL, commonly called URL encoding), e.g. `homeassistant://navigate/dashboard-mobile/my-subview?server=My%20House`
 
-#### Define server
+### Specify server to navigate to
 ![iOS](/assets/iOS.svg) <span class='beta'>BETA</span><br />
 By default the App will ask which server you want to navigate to in case you have multiple servers.
 To define which server you want to navigate to, use the query param `?server=` like the example below:<br /><br />


### PR DESCRIPTION
Trying to follow the documentation here didn't end up navigating the app to the correct URL. I tried removing lovelace and it worked, so I updated the wording here accordingly. I also added an example of a subview since that may not be obvious to all readers.