### PR TITLE
Update Wear OS non-standalone prerequisite

### DIFF
--- a/docs/wear-os/wear-os.md
+++ b/docs/wear-os/wear-os.md
@@ -5,9 +5,13 @@ id: "wear-os"
 
 ![Android](/assets/android.svg) 8+ only
 
-You can access Home Assistant directly from your Wear OS watch, even when not connected to your phone using a WiFi or cellular connection on the watch or when using an iPhone. 
+You can access Home Assistant directly from your Wear OS watch, even when not connected to your phone using a WiFi or cellular connection on the watch.
 
 The app does not support all Home Assistant features. Keep an eye out on this page as the app is enhanced with new features! Take a look at the [Sensors!](sensors.md)
+
+## Prerequisites
+
+To set up Home Assistant on a watch, you need a paired Android phone with the Home Assistant app installed to login. After logging in, the phone app is no longer used.
 
 ## Home Screen
 


### PR DESCRIPTION
- Remove iPhone mention as the app is no longer standalone and only works with the Android app (via https://github.com/home-assistant/android/issues/4970)
- Mention requirement of phone app for sign in in the documentation