### PR TITLE
Use 3001 ports for devcontainer to avoid conflict with dev documentation

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,29 +6,33 @@
         "3001:3000"
     ],
     "postCreateCommand": "yarn install",
-    "extensions": [
-        "davidanson.vscode-markdownlint",
-        "editorconfig.editorconfig",
-        "streetsidesoftware.code-spell-checker",
-        "yzhang.markdown-all-in-one"
-    ],
-    "settings": {
-        "editor.rulers": [
-            80,
-            100,
-            120
-        ],
-        "editor.renderWhitespace": "boundary",
-        "errorLens.gutterIconsEnabled": true,
-        "errorLens.addAnnotationTextPrefixes": false,
-        "errorLens.enabledDiagnosticLevels": [
-            "error",
-            "warning"
-        ],
-        "terminal.integrated.shell.linux": "/bin/bash",
-        "[markdown]": {
-            "editor.wordWrap": "wordWrapColumn",
-            "editor.wordWrapColumn": 80,
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "davidanson.vscode-markdownlint",
+                "editorconfig.editorconfig",
+                "streetsidesoftware.code-spell-checker",
+                "yzhang.markdown-all-in-one"
+            ],
+            "settings": {
+                "editor.rulers": [
+                    80,
+                    100,
+                    120
+                ],
+                "editor.renderWhitespace": "boundary",
+                "errorLens.gutterIconsEnabled": true,
+                "errorLens.addAnnotationTextPrefixes": false,
+                "errorLens.enabledDiagnosticLevels": [
+                    "error",
+                    "warning"
+                ],
+                "terminal.integrated.shell.linux": "/bin/bash",
+                "[markdown]": {
+                    "editor.wordWrap": "wordWrapColumn",
+                    "editor.wordWrapColumn": 80,
+                }
+            }
         }
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,9 @@
 {
     "name": "companion.home-assistant",
     "dockerFile": "Dockerfile",
+    // 3000 is used for dev documentation
     "appPort": [
-        3000
+        "3001:3000"
     ],
     "postCreateCommand": "yarn install",
     "extensions": [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please DO NOT DELETE ANY TEXT from this template unless instructed.
-->

## Proposed change
<!-- 
  Provide a clear and concise description of your changes. Explain the purpose and 
  benefits of this pull request to help maintainers understand why it should be accepted.

  If applicable, use the `<span class='beta'>BETA</span>` flag in the documentation to 
  indicate that a section is not yet available in the apps.
-->
The devcontainer config in the [developers.home-assistant](https://github.com/home-assistant/developers.home-assistant/blob/master/.devcontainer/devcontainer.json) repository uses the port 3000. Updating the port here allows both documentation sites to run in parallel. Without this change, one container must be stopped before the other can start properly.

While this update was made in this documentation, it could also have been addressed in the developer documentation.

Based on https://github.com/home-assistant/developers.home-assistant/pull/2652 the devconfig file has been adjusted.
## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Companion Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant Companion App
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [x] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/general-style-guide).
- [x] I have verified that my changes render correctly in the documentation.
