### PR TITLE
Update Human Interface Guidelines link for complications

### DIFF
--- a/docs/apple-watch/apple-watch.md
+++ b/docs/apple-watch/apple-watch.md
@@ -18,14 +18,14 @@ The Apple Watch integration requires watchOS 8. In order to install watchOS 8 yo
 
 ## Complication types
 
-The Apple Watch has a variety of Faces and Complications. It's useful to consult the [Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/components/system-experiences/complications/) for an example of the different Families and how the particular Complications will display. There are 4 main types of information you can put into Complications:
+The Apple Watch has a variety of Faces and Complications. It's useful to consult the [Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/complications) for an example of the different Families and how the particular Complications will display. There are 4 main types of information you can put into Complications:
 
 - Text, which can render as a [template](https://www.home-assistant.io/docs/configuration/templating/), is displayed at various font weights and sizes depending on the template type.
 - Ring and Gauge, which appear circular lines. An open variant appears as a complete circle and a closed variant has concrete start and end locations in the icon. Rings and Gauges require numeric values between `0.0` (empty) and `1.0` (full) and also support [templates](https://www.home-assistant.io/docs/configuration/templating/).
 - Images can be selected from the [Material Design Icons](http://materialdesignicons.com) choices supported by the app. 
 
 :::info Supported Complication types
-As of watchOS 9, several (legacy) Complication types are no longer supported by Apple. The following Complication types can be used for watchOS 9 and higher: Graphic Circular, Graphic Corner, Graphic Rectangular & Modular Large. Further details on the different types can be found in the [Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/components/system-experiences/complications/).
+As of watchOS 9, several (legacy) Complication types are no longer supported by Apple. The following Complication types can be used for watchOS 9 and higher: Graphic Circular, Graphic Corner, Graphic Rectangular & Modular Large. Further details on the different types can be found in the [Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/complications).
 :::
 
 :::note app version 


### PR DESCRIPTION
Proposed change

Replaced an outdated / inactive Apple Developer documentation link with the current active URL. This ensures readers can access the correct Apple docs without hitting a dead pages.

Type of change

- Updated deprecated URL at https://companion.home-assistant.io/docs/apple-watch/.
