### PR TITLE
Adjust documentation to include the new attributes for volume-levels

### DIFF
--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -274,8 +274,8 @@ Possible volume streams are:
 
 | Attribute | Description |
 | --------- | --------- |
-| `Min` | Provides the minimal value of the volume level can have. Usually this is `0` but can also different based on the used Android Version and distribution. |
-| `Max` | Provides the maximal value of the volume level. This value differs between Android Versions and distributions. |
+| `min` | Provides the minimum value of the volume level. Usually this is `0`, but it can also be different based on the Android version and device manufacturer. |
+| `max` | Provides the maximum value of the volume level. This value differs between Android versions and device manufacturers. |
 
 ## Battery Sensors
 ![iOS](/assets/iOS.svg) <br />


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please DO NOT DELETE ANY TEXT from this template unless instructed.
-->

## Proposed change
<!-- 
  Provide a clear and concise description of your changes. Explain the purpose and 
  benefits of this pull request to help maintainers understand why it should be accepted.

  If applicable, use the `<span class='beta'>BETA</span>` flag in the documentation to 
  indicate that a section is not yet available in the apps.
-->

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Companion Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant Companion App
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/general-style-guide).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Provide any additional context or details that may help maintainers review your PR. 
  Include links to relevant files, pull requests, or issues where applicable.
-->

- This PR fixes or closes issue: None
- Link to relevant existing code or pull request: 
  * [android#6452: Added min/max attributes to volume sensors.](https://github.com/home-assistant/android/pull/6452)
- A very small typo in the same context was fixed `vibriate` -> `vibrate`