### PR TITLE
Add iOS support to pressure sensor documentation

### DIFF
--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -719,8 +719,12 @@ This sensor will show the state of power save mode on the device. Depending on t
 
 
 ## Pressure sensor
-![Android](/assets/android.svg)<br />
-This sensor will show the current pressure reading from the device. This sensor will update during the normal sensor update interval and makes use of [Environment Sensors](https://developer.android.com/guide/topics/sensors/sensors_environment).
+![Android](/assets/android.svg) ![iOS](/assets/iOS.svg)<br />
+This sensor will show the current barometric pressure reading from the device.
+
+![Android](/assets/android.svg) On Android, this sensor will update during the normal sensor update interval and makes use of [Environment Sensors](https://developer.android.com/guide/topics/sensors/sensors_environment).
+
+![iOS](/assets/iOS.svg) On iOS, this sensor reads barometric pressure from the device's built-in barometer using [CMAltimeter](https://developer.apple.com/documentation/coremotion/cmaltimeter). The value is reported in hectopascals (hPa). This sensor requires motion permissions to be enabled.
 
 
 ## Proximity sensor


### PR DESCRIPTION
The iOS companion app now exposes barometric pressure via CMAltimeter, matching the existing Android pressure sensor.

<!--
  You are amazing! Thanks for contributing to our project!
  Please DO NOT DELETE ANY TEXT from this template unless instructed.
-->

## Proposed change
This is a companion PR to one I'm just about to open in the iOS repo, which is to add 'Pressure' support as an entity that the phone reports with, bringing iOS in line with Android. As such, the change is basically just adding the iOS badge to the existing page on pressure, and a paragraph talking about it.

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Companion Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Document existing features within Home Assistant Companion App
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/general-style-guide).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information
<!--
  Provide any additional context or details that may help maintainers review your PR. 
  Include links to relevant files, pull requests, or issues where applicable.
-->

- This PR fixes or closes issue: Fixes #
- Link to relevant existing code or pull request: https://github.com/home-assistant/iOS/pull/4491
