### PR TITLE
Document kiosk set brightness and set volume commands

### DIFF
--- a/docs/integrations/ios-kiosk-mode.md
+++ b/docs/integrations/ios-kiosk-mode.md
@@ -103,7 +103,7 @@ The available commands are:
 
 | `message` | Action |
 | --------- | ------ |
-| `kiosk_show_screensaver` | Show the screensaver immediately. |
+| `kiosk_show_screensaver` | Show the screensaver immediately. Requires screensaver enabled in kiosk settings. |
 | `kiosk_hide_screensaver` | Hide the screensaver and reset the inactivity timer. |
 | `kiosk_show_camera` | Show a full-screen camera stream. Requires an `entity_id` pointing to a `camera.` entity. |
 | `kiosk_hide_camera` | Hide the camera stream. |

--- a/docs/integrations/ios-kiosk-mode.md
+++ b/docs/integrations/ios-kiosk-mode.md
@@ -110,6 +110,7 @@ The available commands are:
 | `kiosk_set_brightness` | Set the screen brightness. Requires `level`, a percentage from `0` to `100`. |
 | `kiosk_set_volume` | Set the system volume. Requires `volume`, a percentage from `0` to `100`. |
 | `kiosk_reload` | Reload the dashboard. |
+| `kiosk_default` | Return to the configured kiosk server and dashboard (or the server default when no dashboard is set). Useful to make sure the kiosk is back on its main dashboard after someone has navigated away. |
 
 ```yaml
 automation:

--- a/docs/integrations/ios-kiosk-mode.md
+++ b/docs/integrations/ios-kiosk-mode.md
@@ -109,6 +109,7 @@ The available commands are:
 | `kiosk_hide_camera` | Hide the camera stream. |
 | `kiosk_set_brightness` | Set the screen brightness. Requires `level`, a percentage from `0` to `100`. |
 | `kiosk_set_volume` | Set the system volume. Requires `volume`, a percentage from `0` to `100`. |
+| `kiosk_reload` | Reload the dashboard. |
 
 ```yaml
 automation:

--- a/docs/integrations/ios-kiosk-mode.md
+++ b/docs/integrations/ios-kiosk-mode.md
@@ -107,6 +107,8 @@ The available commands are:
 | `kiosk_hide_screensaver` | Hide the screensaver and reset the inactivity timer. |
 | `kiosk_show_camera` | Show a full-screen camera stream. Requires an `entity_id` pointing to a `camera.` entity. |
 | `kiosk_hide_camera` | Hide the camera stream. |
+| `kiosk_set_brightness` | Set the screen brightness. Requires `level`, a percentage from `0` to `100`. |
+| `kiosk_set_volume` | Set the system volume. Requires `volume`, a percentage from `0` to `100`. |
 
 ```yaml
 automation:

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -14,7 +14,7 @@ The Companion apps offer a lot of different notification options. In place of po
 | `clear_notification` | Removes a notification, [more details](basic.md#clearing). |
 | `update_complications` | Updates the complications on a paired Apple Watch. [More details](/apple-watch/complications.md). |
 | `update_widgets`* | Updates 'Gauge' and 'Details' widgets introduced on App v2024.7 (iOS will decide if the update is allowed or not, so don't worry if it doesn't work all the time). |
-| `kiosk_show_screensaver` | Shows the kiosk screensaver. Only works while the app is open, [see below](#kiosk-mode-commands). |
+| `kiosk_show_screensaver` | Shows the kiosk screensaver. Only works while the app is open, [see below](#kiosk-mode-commands). Requires screensaver enabled in kiosk settings. |
 | `kiosk_hide_screensaver` | Hides the kiosk screensaver. Only works while the app is open, [see below](#kiosk-mode-commands). |
 | `kiosk_show_camera` | Shows a full-screen camera (requires `entity_id`). Only works while the app is open, [see below](#kiosk-mode-commands). |
 | `kiosk_hide_camera` | Hides the full-screen camera. Only works while the app is open, [see below](#kiosk-mode-commands). |

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -21,6 +21,7 @@ The Companion apps offer a lot of different notification options. In place of po
 | `kiosk_set_brightness` | Sets the screen brightness (requires `level`). Only works while the app is open, [see below](#kiosk-mode-commands). |
 | `kiosk_set_volume` | Sets the system volume (requires `volume`). Only works while the app is open, [see below](#kiosk-mode-commands). |
 | `kiosk_reload` | Reloads the dashboard. Only works while the app is open, [see below](#kiosk-mode-commands). |
+| `kiosk_default` | Returns to the configured kiosk server and dashboard. Only works while the app is open, [see below](#kiosk-mode-commands). |
 
 \* On iOS, manual widget reloads are limited to around 40-70 per 24 hour, depending on how often you look at the widget. This will not always reset at exactly midnight.
 
@@ -544,6 +545,7 @@ Kiosk commands are only handled while the Companion app is open and in the foreg
 | `kiosk_set_brightness` | Set the screen brightness. Requires `level`. |
 | `kiosk_set_volume` | Set the system volume. Requires `volume`. |
 | `kiosk_reload` | Reload the dashboard. |
+| `kiosk_default` | Return to the configured kiosk server and dashboard (or the server default when no dashboard is set). Useful to make sure the kiosk is back on its main dashboard after someone has navigated away. |
 
 `level` and `volume` are a percentage from `0` to `100`. A value of `1` or less is treated as a fraction, so `0.5` is the same as `50`.
 

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -18,6 +18,8 @@ The Companion apps offer a lot of different notification options. In place of po
 | `kiosk_hide_screensaver` | Hides the kiosk screensaver. Only works while the app is open, [see below](#kiosk-mode-commands). |
 | `kiosk_show_camera` | Shows a full-screen camera (requires `entity_id`). Only works while the app is open, [see below](#kiosk-mode-commands). |
 | `kiosk_hide_camera` | Hides the full-screen camera. Only works while the app is open, [see below](#kiosk-mode-commands). |
+| `kiosk_set_brightness` | Sets the screen brightness (requires `level`). Only works while the app is open, [see below](#kiosk-mode-commands). |
+| `kiosk_set_volume` | Sets the system volume (requires `volume`). Only works while the app is open, [see below](#kiosk-mode-commands). |
 
 \* On iOS, manual widget reloads are limited to around 40-70 per 24 hour, depending on how often you look at the widget. This will not always reset at exactly midnight.
 
@@ -538,6 +540,10 @@ Kiosk commands are only handled while the Companion app is open and in the foreg
 | `kiosk_hide_screensaver` | Hide the screensaver and reset the inactivity timer. |
 | `kiosk_show_camera` | Show a full-screen camera stream. Requires an `entity_id` pointing to a `camera.` entity. |
 | `kiosk_hide_camera` | Hide the camera stream. |
+| `kiosk_set_brightness` | Set the screen brightness. Requires `level`. |
+| `kiosk_set_volume` | Set the system volume. Requires `volume`. |
+
+`level` and `volume` are a percentage from `0` to `100`. A value of `1` or less is treated as a fraction, so `0.5` is the same as `50`.
 
 ```yaml
 automation:
@@ -561,6 +567,24 @@ automation:
           message: "kiosk_show_camera"
           data:
             entity_id: "camera.front_door"
+```
+
+```yaml
+automation:
+  - alias: Dim the kiosk and lower its volume at night
+    trigger:
+      ...
+    action:
+      - action: notify.mobile_app_<your_device_id_here>
+        data:
+          message: "kiosk_set_brightness"
+          data:
+            level: 20
+      - action: notify.mobile_app_<your_device_id_here>
+        data:
+          message: "kiosk_set_volume"
+          data:
+            volume: 30
 ```
 
 ## Launch App

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -20,6 +20,7 @@ The Companion apps offer a lot of different notification options. In place of po
 | `kiosk_hide_camera` | Hides the full-screen camera. Only works while the app is open, [see below](#kiosk-mode-commands). |
 | `kiosk_set_brightness` | Sets the screen brightness (requires `level`). Only works while the app is open, [see below](#kiosk-mode-commands). |
 | `kiosk_set_volume` | Sets the system volume (requires `volume`). Only works while the app is open, [see below](#kiosk-mode-commands). |
+| `kiosk_reload` | Reloads the dashboard. Only works while the app is open, [see below](#kiosk-mode-commands). |
 
 \* On iOS, manual widget reloads are limited to around 40-70 per 24 hour, depending on how often you look at the widget. This will not always reset at exactly midnight.
 
@@ -542,6 +543,7 @@ Kiosk commands are only handled while the Companion app is open and in the foreg
 | `kiosk_hide_camera` | Hide the camera stream. |
 | `kiosk_set_brightness` | Set the screen brightness. Requires `level`. |
 | `kiosk_set_volume` | Set the system volume. Requires `volume`. |
+| `kiosk_reload` | Reload the dashboard. |
 
 `level` and `volume` are a percentage from `0` to `100`. A value of `1` or less is treated as a fraction, so `0.5` is the same as `50`.
 


### PR DESCRIPTION
## Proposed change

Documents the `kiosk_set_brightness` and `kiosk_set_volume` kiosk mode push notification commands, which set the screen brightness / system volume from the value in the notification payload. They are added alongside the existing screensaver and camera kiosk commands in:

- the iOS notification commands list,
- the **Kiosk mode commands** section (with an example), and
- the iOS Kiosk mode **Remote commands** section.

`level` / `volume` accept a percentage from `0` to `100` (a value of `1` or less is treated as a fraction).

## Type of change

- [ ] Document existing features within Home Assistant Companion App
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/general-style-guide).
- [ ] I have verified that my changes render correctly in the documentation.

## Additional information

- This PR fixes or closes issue: Fixes #
- Link to relevant existing code or pull request: home-assistant/iOS#4845 (app), home-assistant/mobile-apps-fcm-push#329 (push proxy)
