### PR TITLE
Android 17 ringer mode - background audio hardening documentation

### DIFF
--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -679,19 +679,17 @@ While it is possible to create an automation in Home Assistant to call this acti
 On Android you can control the device\'s ringer mode by sending `message: command_ringer_mode` with an appropriate `command` as outlined in the table below. Certain devices will need to grant a special permission that will appear upon the first command received if the permission was not already granted. This is the same permission as [Do Not Disturb](#do-not-disturb) up above. If the device has Do Not Disturb enabled then setting to `normal` or `vibrate` will turn it off. If the device does not have Do Not Disturb enabled then `silent` will turn it on.<br />
 
 :::caution
-### Android 17 and Background Audio Hardening
-
 Starting with Android 17, Android may block notification commands that change the ringer mode when they are executed in the background. This is caused by Android's **Background Audio Hardening**, which restricts background audio interactions, including volume and ringer mode changes, unless they are started from a visible app or an eligible foreground service.
 
 See the official Android documentation: https://developer.android.com/about/versions/17/changes/bg-audio
 
 If ringer mode commands no longer work on Android 17, you can temporarily disable this system hardening with ADB:
 
-```bash adb shell cmd audio set-hardening 0 ```
+```bash adb shell cmd audio set-hardening 0```
 
 To re-enable it:
 
-```bash adb shell cmd audio set-hardening 1 ```
+```bash adb shell cmd audio set-hardening 1```
 
 Disabling this protection is a system-wide developer workaround and is not recommended for normal use. It may allow apps to change audio behavior from the background without clear user interaction, which can lead to unexpected ringer, volume, or audio playback changes.
 :::

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -690,6 +690,8 @@ To re-enable it:
 ```adb shell cmd audio set-hardening 1```
 
 Disabling this protection is a system-wide developer workaround and is not recommended for normal use. It may allow apps to change audio behavior from the background without clear user interaction, which can lead to unexpected ringer, volume, or audio playback changes.
+
+Note that this ADB command does not persist across device restarts. You must run it again after each reboot.
 :::
 
 | `command` | Description |

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -678,6 +678,24 @@ While it is possible to create an automation in Home Assistant to call this acti
 
 On Android you can control the device\'s ringer mode by sending `message: command_ringer_mode` with an appropriate `command` as outlined in the table below. Certain devices will need to grant a special permission that will appear upon the first command received if the permission was not already granted. This is the same permission as [Do Not Disturb](#do-not-disturb) up above. If the device has Do Not Disturb enabled then setting to `normal` or `vibrate` will turn it off. If the device does not have Do Not Disturb enabled then `silent` will turn it on.<br />
 
+:::caution
+### Android 17 and Background Audio Hardening
+
+Starting with Android 17, Android may block notification commands that change the ringer mode when they are executed in the background. This is caused by Android's **Background Audio Hardening**, which restricts background audio interactions, including volume and ringer mode changes, unless they are started from a visible app or an eligible foreground service.
+
+See the official Android documentation: https://developer.android.com/about/versions/17/changes/bg-audio
+
+If ringer mode commands no longer work on Android 17, you can temporarily disable this system hardening with ADB:
+
+```bash adb shell cmd audio set-hardening 0 ```
+
+To re-enable it:
+
+```bash adb shell cmd audio set-hardening 1 ```
+
+Disabling this protection is a system-wide developer workaround and is not recommended for normal use. It may allow apps to change audio behavior from the background without clear user interaction, which can lead to unexpected ringer, volume, or audio playback changes.
+:::
+
 | `command` | Description |
 | ------- | ----------- |
 | `normal` | Set the device to normal ringer mode, will turn off Do Not Disturb if enabled and supported. |

--- a/docs/notifications/commands.md
+++ b/docs/notifications/commands.md
@@ -679,17 +679,15 @@ While it is possible to create an automation in Home Assistant to call this acti
 On Android you can control the device\'s ringer mode by sending `message: command_ringer_mode` with an appropriate `command` as outlined in the table below. Certain devices will need to grant a special permission that will appear upon the first command received if the permission was not already granted. This is the same permission as [Do Not Disturb](#do-not-disturb) up above. If the device has Do Not Disturb enabled then setting to `normal` or `vibrate` will turn it off. If the device does not have Do Not Disturb enabled then `silent` will turn it on.<br />
 
 :::caution
-Starting with Android 17, Android may block notification commands that change the ringer mode when they are executed in the background. This is caused by Android's **Background Audio Hardening**, which restricts background audio interactions, including volume and ringer mode changes, unless they are started from a visible app or an eligible foreground service.
-
-See the official Android documentation: https://developer.android.com/about/versions/17/changes/bg-audio
+Starting with Android 17, Android may block notification commands that change the ringer mode when they are executed in the background. This is caused by Android's [**Background Audio Hardening**](https://developer.android.com/about/versions/17/changes/bg-audio), which restricts background audio interactions, including volume and ringer mode changes, unless they are started from a visible app or an eligible foreground service.
 
 If ringer mode commands no longer work on Android 17, you can temporarily disable this system hardening with ADB:
 
-```bash adb shell cmd audio set-hardening 0```
+```adb shell cmd audio set-hardening 0```
 
 To re-enable it:
 
-```bash adb shell cmd audio set-hardening 1```
+```adb shell cmd audio set-hardening 1```
 
 Disabling this protection is a system-wide developer workaround and is not recommended for normal use. It may allow apps to change audio behavior from the background without clear user interaction, which can lead to unexpected ringer, volume, or audio playback changes.
 :::


### PR DESCRIPTION
## Proposed change

This PR adds a short troubleshooting note for Android 17 ringer mode notification commands.

Starting with Android 17, Android may block background audio interactions due to the new Background Audio Hardening behavior. This can cause ringer mode commands to silently fail when they are executed in the background, even when the required notification policy access permission is granted.

The added documentation explains why this can happen, links to the official Android documentation, and shows the ADB commands to temporarily disable or re-enable this hardening behavior.

<img width="1008" height="752" alt="grafik" src="https://github.com/user-attachments/assets/68f6f62e-5cd1-4d8a-be9b-1cf992f90ddd" />


## Type of change

- [X] Document existing features within Home Assistant Companion App
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity 
- [ ] Changes to the backend of this documentation 
- [ ] Remove stale or deprecated documentation

## Checklist

- [X] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/general-style-guide).
- [X] I have verified that my changes render correctly in the documentation.

## Additional information

This PR fixes or closes issue: Fixes # 
Link to relevant existing code or pull request:

Android documentation: https://developer.android.com/about/versions/17/changes/bg-audio