### PR TITLE
Document iOS snooze notification actions

### DIFF
--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -99,6 +99,14 @@ action:
             icon: "sfsymbols:bell.slash"
 ```
 
+### ![iOS](/assets/iOS.svg) Snooze actions
+
+On iOS and macOS the app adds snooze actions to notifications automatically, so you do not need to configure them. Snoozing hides the notification and shows it again after the amount of time you pick.
+
+You can manage these under Settings, Notifications, Snooze Actions. Some durations are enabled by default, and you can add your own durations or turn off the ones you do not want.
+
+When a snoozed notification comes back, its title is prefixed with "↺" so you can tell it was snoozed.
+
 ### `uri` values
 
 To navigate to a frontend page, use the format `/lovelace/test` where `test` is replaced by your defined [`path`](https://www.home-assistant.io/dashboards/views/#path) in the defined view. If you plan to use a dashboard the format would be `/lovelace-dashboard/view` where `/lovelace-dashboard/` is replaced by your defined [`dashboard`](https://www.home-assistant.io/dashboards/dashboards) URL and `view` is replaced by the defined [`path`](https://www.home-assistant.io/dashboards/views/#path) within that dashboard. For example:

--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -99,7 +99,7 @@ action:
             icon: "sfsymbols:bell.slash"
 ```
 
-### ![iOS](/assets/iOS.svg) Snooze actions
+### Snooze actions
 
 On iOS and macOS the app adds snooze actions to notifications automatically, so you do not need to configure them. Snoozing hides the notification and shows it again after the amount of time you pick.
 

--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -107,6 +107,9 @@ You can manage these under **Settings** > **Companion app** > **Notifications** 
 
 When a snoozed notification comes back, its title is prefixed with "↺" so you can tell it was snoozed.
 
+:::tip
+Android 8.0+ natively supports snoozing notifications from any app, including Home Assistant. You may need to enable notification snoozing in the system settings for notifications.
+:::
 ### `uri` values
 
 To navigate to a frontend page, use the format `/lovelace/test` where `test` is replaced by your defined [`path`](https://www.home-assistant.io/dashboards/views/#path) in the defined view. If you plan to use a dashboard the format would be `/lovelace-dashboard/view` where `/lovelace-dashboard/` is replaced by your defined [`dashboard`](https://www.home-assistant.io/dashboards/dashboards) URL and `view` is replaced by the defined [`path`](https://www.home-assistant.io/dashboards/views/#path) within that dashboard. For example:

--- a/docs/notifications/actionable.md
+++ b/docs/notifications/actionable.md
@@ -103,7 +103,7 @@ action:
 
 On iOS and macOS the app adds snooze actions to notifications automatically, so you do not need to configure them. Snoozing hides the notification and shows it again after the amount of time you pick.
 
-You can manage these under Settings, Notifications, Snooze Actions. Some durations are enabled by default, and you can add your own durations or turn off the ones you do not want.
+You can manage these under **Settings** > **Companion app** > **Notifications** >  **Snooze Actions**. Some durations are enabled by default, and you can add your own durations or turn off the ones you do not want.
 
 When a snoozed notification comes back, its title is prefixed with "↺" so you can tell it was snoozed.
 


### PR DESCRIPTION
## Summary

Documents the built-in snooze actions on iOS and macOS in the actionable notifications page.

The app automatically adds snooze actions to notifications, so users do not need to configure them. This adds a short section explaining that:

- Users get snooze options by default and can add their own durations or turn off the ones they do not want, managed under Settings, Notifications, Snooze Actions.
- When a snoozed notification comes back, its title is prefixed with "↺" so it is clear it was snoozed.

Companion to the app change that adds the "↺" prefix to re-delivered snoozed notifications.