### PR TITLE
Add kiosk sensors (including screensaver) to iOS Kiosk mode docs

### DIFF
--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -53,6 +53,7 @@ Not all ![iOS](/assets/iOS.svg) sensors are enabled by default. If you don't see
 | `sensor.distance` | None | The estimated distance walked by the user since midnight local time. Units: meters, m |
 | `sensor.floors_ascended` | None | The approximate number of floors ascended by walking since midnight local time. |
 | `sensor.floors_descended` | None | The approximate number of floors descended by walking. Since |
+| [Kiosk Sensors](#kiosk-sensors) | None | Sensors exposed by [Kiosk mode](../integrations/ios-kiosk-mode.md), reflecting the state of the kiosk device. |
 | `sensor.location_permission` | None | The current location permission that was selected by the user. The permission can be set via the location permission popup or modified in the iOS settings. |
 | `sensor.sim_1` | [See Below](#cellular-provider-sensor) | Name of your cellular provider. |
 | `sensor.sim_2` | [See Below](#cellular-provider-sensor) | Name of your cellular provider. |
@@ -556,6 +557,17 @@ Using the [History Stats Integration](https://www.home-assistant.io/integrations
 ![Android](/assets/android.svg)
 
 These sensors will reflect various states from the [Keyguard Manager](https://developer.android.com/reference/android/app/KeyguardManager). You will be able to determine if the device is actively locked, has a password setup or even if the device requires a password to unlock. These sensors will update with the periodic sensor interval.
+
+## Kiosk sensors
+![iOS](/assets/iOS.svg)<br />
+[Kiosk mode](../integrations/ios-kiosk-mode.md) adds sensors so automations can react to the state of the kiosk device. The **Kiosk Brightness**, **Kiosk Volume**, and **Kiosk Screensaver** sensors are only active while kiosk mode is enabled and turn on and off automatically as you enable or disable it. The **Kiosk Mode** sensor is always available so you can tell whether a device is currently acting as a kiosk. See [Kiosk mode](../integrations/ios-kiosk-mode.md#sensors) for the full description.
+
+| Sensor | Type | Description |
+| ------ | ---- | ----------- |
+| **Kiosk Mode** | `binary_sensor` | `on` while the app is running in kiosk mode, `off` otherwise. |
+| **Kiosk Brightness** | `sensor` (%) | The current screen brightness, as a percentage. |
+| **Kiosk Volume** | `sensor` (%) | The current device output volume, as a percentage. |
+| **Kiosk Screensaver** | `binary_sensor` | `on` while the screensaver is visible on screen, `off` when it is not. |
 
 ## Last reboot sensor
 ![Android](/assets/android.svg)<br />

--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -560,14 +560,14 @@ These sensors will reflect various states from the [Keyguard Manager](https://de
 
 ## Kiosk sensors
 ![iOS](/assets/iOS.svg)<br />
-[Kiosk mode](../integrations/ios-kiosk-mode.md) adds sensors so automations can react to the state of the kiosk device. The **Kiosk Brightness**, **Kiosk Volume**, and **Kiosk Screensaver** sensors are only active while kiosk mode is enabled and turn on and off automatically as you enable or disable it. The **Kiosk Mode** sensor is always available so you can tell whether a device is currently acting as a kiosk. See [Kiosk mode](../integrations/ios-kiosk-mode.md#sensors) for the full description.
+[Kiosk mode](../integrations/ios-kiosk-mode.md) adds sensors so automations can react to the state of the kiosk device. The `sensor.kiosk_brightness`, `sensor.kiosk_volume`, and `binary_sensor.kiosk_screensaver` sensors are only active while kiosk mode is enabled and turn on and off automatically as you enable or disable it. The `binary_sensor.kiosk_mode` sensor is always available so you can tell whether a device is currently acting as a kiosk. See [Kiosk mode](../integrations/ios-kiosk-mode.md#sensors) for the full description.
 
-| Sensor | Type | Description |
-| ------ | ---- | ----------- |
-| **Kiosk Mode** | `binary_sensor` | `on` while the app is running in kiosk mode, `off` otherwise. |
-| **Kiosk Brightness** | `sensor` (%) | The current screen brightness, as a percentage. |
-| **Kiosk Volume** | `sensor` (%) | The current device output volume, as a percentage. |
-| **Kiosk Screensaver** | `binary_sensor` | `on` while the screensaver is visible on screen, `off` when it is not. |
+| Sensor | Description |
+| ------ | ----------- |
+| `binary_sensor.kiosk_mode` | `on` while the app is running in kiosk mode, `off` otherwise. |
+| `sensor.kiosk_brightness` | The current screen brightness, as a percentage. |
+| `sensor.kiosk_volume` | The current device output volume, as a percentage. |
+| `binary_sensor.kiosk_screensaver` | `on` while the screensaver is visible on screen, `off` when it is not. |
 
 ## Last reboot sensor
 ![Android](/assets/android.svg)<br />

--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -560,14 +560,17 @@ These sensors will reflect various states from the [Keyguard Manager](https://de
 
 ## Kiosk sensors
 ![iOS](/assets/iOS.svg)<br />
-[Kiosk mode](../integrations/ios-kiosk-mode.md) adds sensors so automations can react to the state of the kiosk device. The `sensor.kiosk_brightness`, `sensor.kiosk_volume`, and `binary_sensor.kiosk_screensaver` sensors are only active while kiosk mode is enabled and turn on and off automatically as you enable or disable it. The `binary_sensor.kiosk_mode` sensor is always available so you can tell whether a device is currently acting as a kiosk. See [Kiosk mode](../integrations/ios-kiosk-mode.md#sensors) for the full description.
+[Kiosk mode](../integrations/ios-kiosk-mode.md) adds sensors so automations can react to the state of the kiosk device.
+
+The `binary_sensor.kiosk_mode` sensor is always available so you can tell whether a device is currently acting as a kiosk (`on`) or running the app normally (`off`).
+
+While kiosk mode is on, additional sensors provide details about the device in kiosk mode:
 
 | Sensor | Description |
 | ------ | ----------- |
-| `binary_sensor.kiosk_mode` | `on` while the app is running in kiosk mode, `off` otherwise. |
 | `sensor.kiosk_brightness` | The current screen brightness, as a percentage. |
-| `sensor.kiosk_volume` | The current device output volume, as a percentage. |
 | `binary_sensor.kiosk_screensaver` | `on` while the screensaver is visible on screen, `off` when it is not. |
+| `sensor.kiosk_volume` | The current device output volume, as a percentage. |
 
 ## Last reboot sensor
 ![Android](/assets/android.svg)<br />

--- a/docs/integrations/ios-kiosk-mode.md
+++ b/docs/integrations/ios-kiosk-mode.md
@@ -87,6 +87,19 @@ When **Mode** is set to **Clock**, you can also adjust:
 
 Use the **Preview** button to see the screensaver full-screen with your current settings. Tap anywhere to return to the settings.
 
+## Sensors
+
+Kiosk mode adds sensors so automations can react to the state of the kiosk device. They appear in the app's sensor settings and in the **Sensors** screen inside the kiosk settings. All are iOS-only.
+
+| Sensor | Type | Description |
+| ------ | ---- | ----------- |
+| **Kiosk Mode** | `binary_sensor` | `on` while the app is running in kiosk mode, `off` otherwise. |
+| **Kiosk Brightness** | `sensor` (%) | The current screen brightness, as a percentage. |
+| **Kiosk Volume** | `sensor` (%) | The current device output volume, as a percentage. |
+| **Kiosk Screensaver** | `binary_sensor` | `on` while the screensaver is visible on screen, `off` when it is not. |
+
+The **Kiosk Brightness**, **Kiosk Volume**, and **Kiosk Screensaver** sensors are only active while kiosk mode is enabled — they are turned on and off automatically as you enable or disable kiosk mode. The **Kiosk Mode** sensor is always available so you can tell whether a device is currently acting as a kiosk.
+
 ## Remote commands
 
 While kiosk mode is running, you can control it from Home Assistant by sending a notification whose `message` is a kiosk command. This is useful for automations — for example, showing the screensaver at night, or bringing a camera up on a wall panel when motion is detected.

--- a/docs/integrations/ios-kiosk-mode.md
+++ b/docs/integrations/ios-kiosk-mode.md
@@ -91,14 +91,7 @@ Use the **Preview** button to see the screensaver full-screen with your current 
 
 Kiosk mode adds sensors so automations can react to the state of the kiosk device. They appear in the app's sensor settings and in the **Sensors** screen inside the kiosk settings. All are iOS-only.
 
-| Sensor | Description |
-| ------ | ----------- |
-| `binary_sensor.kiosk_mode` | `on` while the app is running in kiosk mode, `off` otherwise. |
-| `sensor.kiosk_brightness` | The current screen brightness, as a percentage. |
-| `sensor.kiosk_volume` | The current device output volume, as a percentage. |
-| `binary_sensor.kiosk_screensaver` | `on` while the screensaver is visible on screen, `off` when it is not. |
-
-The `sensor.kiosk_brightness`, `sensor.kiosk_volume`, and `binary_sensor.kiosk_screensaver` sensors are only active while kiosk mode is enabled — they are turned on and off automatically as you enable or disable kiosk mode. The `binary_sensor.kiosk_mode` sensor is always available so you can tell whether a device is currently acting as a kiosk.
+For the full list of these sensors and what each one reports, see [Kiosk sensors](../core/sensors.md#kiosk-sensors) on the sensors page.
 
 ## Remote commands
 

--- a/docs/integrations/ios-kiosk-mode.md
+++ b/docs/integrations/ios-kiosk-mode.md
@@ -91,14 +91,14 @@ Use the **Preview** button to see the screensaver full-screen with your current 
 
 Kiosk mode adds sensors so automations can react to the state of the kiosk device. They appear in the app's sensor settings and in the **Sensors** screen inside the kiosk settings. All are iOS-only.
 
-| Sensor | Type | Description |
-| ------ | ---- | ----------- |
-| **Kiosk Mode** | `binary_sensor` | `on` while the app is running in kiosk mode, `off` otherwise. |
-| **Kiosk Brightness** | `sensor` (%) | The current screen brightness, as a percentage. |
-| **Kiosk Volume** | `sensor` (%) | The current device output volume, as a percentage. |
-| **Kiosk Screensaver** | `binary_sensor` | `on` while the screensaver is visible on screen, `off` when it is not. |
+| Sensor | Description |
+| ------ | ----------- |
+| `binary_sensor.kiosk_mode` | `on` while the app is running in kiosk mode, `off` otherwise. |
+| `sensor.kiosk_brightness` | The current screen brightness, as a percentage. |
+| `sensor.kiosk_volume` | The current device output volume, as a percentage. |
+| `binary_sensor.kiosk_screensaver` | `on` while the screensaver is visible on screen, `off` when it is not. |
 
-The **Kiosk Brightness**, **Kiosk Volume**, and **Kiosk Screensaver** sensors are only active while kiosk mode is enabled — they are turned on and off automatically as you enable or disable kiosk mode. The **Kiosk Mode** sensor is always available so you can tell whether a device is currently acting as a kiosk.
+The `sensor.kiosk_brightness`, `sensor.kiosk_volume`, and `binary_sensor.kiosk_screensaver` sensors are only active while kiosk mode is enabled — they are turned on and off automatically as you enable or disable kiosk mode. The `binary_sensor.kiosk_mode` sensor is always available so you can tell whether a device is currently acting as a kiosk.
 
 ## Remote commands
 


### PR DESCRIPTION
## Proposed change

Documents the sensors exposed by iOS Kiosk mode, including the new **Kiosk Screensaver** binary sensor. The kiosk mode page previously documented settings and remote commands but not the sensors the app exposes. This adds a **Sensors** section covering **Kiosk Mode**, **Kiosk Brightness**, **Kiosk Volume**, and the newly added **Kiosk Screensaver** (`on` while the screensaver is on screen, `off` otherwise).

Companion to app PR: home-assistant/iOS#5063

## Type of change

- [ ] Document existing features within Home Assistant Companion App
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/general-style-guide).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information

- This PR fixes or closes issue: Fixes #
- Link to relevant existing code or pull request: home-assistant/iOS#5063

---
_Generated by [Claude Code](https://claude.ai/code/session_014bZsB3ashxLB2dgBSnobAt)_