### PR TITLE
Document iOS entity notification links

### DIFF
--- a/docs/notifications/basic.md
+++ b/docs/notifications/basic.md
@@ -64,6 +64,7 @@ When tapping on a notification, you can choose to open a URL, which can fall int
 - For a particular action in Actionable Notifications, see [its documentation](/docs/notifications/actionable-notifications).
 - ![Android](/assets/android.svg) An application using `app://<package name>` where `<package name>` is replaced with the actual package you wish to open.
 - ![Android](/assets/android.svg) The More Info panel of an entity using `entityId:<entity_ID>` where `<entity_id>` is replaced with the entity ID you wish to view. Ex: `entityId:sun.sun`.
+- ![iOS](/assets/iOS.svg) The More Info panel of an entity using `entity_id: <entity_ID>` where `<entity_id>` is replaced with the entity ID you wish to view. Ex: `entity_id: sun.sun`. This only applies when tapping the notification itself and no `url` is set.
 - ![Android](/assets/android.svg) You can also open the notification history by using `settings://notification_history`
 - ![Android](/assets/android.svg) You can also use an [intent scheme URI](https://developer.chrome.com/docs/multidevice/android/intents/#syntax) to start an action in an installed application.
 - ![Android](/assets/android.svg) You can send a specific [deep link](https://developer.android.com/training/app-links#deep-links) to an app by using `deep-link://<deep_link>` where `<deep_link>` is the actual deep link you wish to send.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please DO NOT DELETE ANY TEXT from this template unless instructed.
-->

## Proposed change

Document the iOS-only `entity_id` notification-tap behavior. When the notification itself is tapped and no `url` is set, the iOS app opens the specified entity More Info dialog.
<!-- 
  Provide a clear and concise description of your changes. Explain the purpose and 
  benefits of this pull request to help maintainers understand why it should be accepted.

  If applicable, use the `<span class='beta'>BETA</span>` flag in the documentation to 
  indicate that a section is not yet available in the apps.
-->

## Type of change
<!--
  What type of change does your pull request introduce to Home Assistant Companion Documentation? Put an `x` in the appropriate box
  NOTE: Please, check only 1! box! 
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Document existing features within Home Assistant Companion App
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist
<!--
  Ensure your pull request meets the following requirements. This helps speed up the review process.
-->

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/general-style-guide).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information

### How to test

1. In Home Assistant, open **Developer tools** > **Actions**.
2. Select your iOS Companion App notification action: `notify.mobile_app_<your_device_id_here>`.
3. Enter the following data, replacing the entity ID if desired:

```yaml
title: Entity link test
message: Tap this notification to open the entity.
data:
  entity_id: sun.sun
```

<img width="979" height="525" alt="image" src="https://github.com/user-attachments/assets/24cc08e0-163e-43c0-a25f-52ed26ae650b" />


4. Perform the action, then tap the notification itself on the iPhone. The More Info dialog for `sun.sun` should open. Do not set `url`; it takes precedence over `entity_id`.

### Implementation proof

- [#4803 / `d0c784273`](https://github.com/home-assistant/iOS/commit/d0c784273) (as [summarized by copilot](https://github.com/home-assistant/iOS/pull/4803#pullrequestreview-4548349250)) adds the notification-tap fallback. It reads `userInfo["entity_id"]` only after checking for a URL, then opens the entity More Info deep link.
- [#3630 / `11d67f320`](https://github.com/home-assistant/iOS/commit/11d67f320) added `openEntityDeeplinkURL`, which constructs the generic entity More Info deep link.
- The legacy push parser has preserved `entity_id` in notification payloads since [`8aac1ce62`](https://github.com/home-assistant/iOS/commit/8aac1ce62).

The Android `clickAction: "entityId:<entity_id>"` behavior is already documented alongside this addition.


<!--
  Provide any additional context or details that may help maintainers review your PR. 
  Include links to relevant files, pull requests, or issues where applicable.
-->

- This PR fixes or closes issue: Fixes #
- Link to relevant existing code or pull request: [#4803 / `d0c784273`](https://github.com/home-assistant/iOS/commit/d0c784273)