### PR TITLE
Added documentation for Nutrition sensors

### DIFF
--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -535,10 +535,6 @@ These sensors will reflect health and fitness data stored by other apps on your 
 | `health_connect_daily_floors` | floors | Total floors climbed since midnight. |
 | `health_connect_daily_hydration` | milliliters | Total hydration since midnight. |
 | `health_connect_daily_steps` | steps | Total steps taken since midnight. |
-| `health_connect_nutrition_calories` | kilocalories | Total calories eaten since midnight. |
-| `health_connect_nutrition_carbohydrates` | grams | Total carbohydrates eaten since midnight. |
-| `health_connect_nutrition_fat` | grams | Total fat eaten since midnight. |
-| `health_connect_nutrition_protein` | grams | Total protein eaten since midnight. |
 | `health_connect_diastolic_blood_pressure` | millimeters of Mercury | The last recorded diastolic blood pressure. |
 | `health_connect_heart_rate` | beats per minute | The last recorded heart rate. |
 | `health_connect_heart_rate_variability` | milliseconds | The last recorded heart rate variability. |
@@ -552,6 +548,17 @@ These sensors will reflect health and fitness data stored by other apps on your 
 | `health_connect_total_calories_burned` | kilocalories | Total amount of calories burned since midnight, including active & basal energy burned (BMR). |
 | `health_connect_vo2_max` | milliliters per minute per kilogram | The last recorded VO2 max score. |
 | `health_connect_weight` | grams | The last recorded weight. |
+
+### <span class='beta'>BETA</span> Nutrition sensors
+
+These sensors provide daily nutrition totals from Nutrition records stored in Health Connect. They require the Android app's Nutrition support to be available.
+
+| Sensor | Unit | Description |
+| --------- | ---- | --------- |
+| `health_connect_nutrition_calories` | kilocalories | Total calories eaten since midnight. |
+| `health_connect_nutrition_carbohydrates` | grams | Total carbohydrates eaten since midnight. |
+| `health_connect_nutrition_fat` | grams | Total fat eaten since midnight. |
+| `health_connect_nutrition_protein` | grams | Total protein eaten since midnight. |
 
 ## High accuracy mode
 ![Android](/assets/android.svg) This sensors state will reflect if the device has [high accuracy mode](location.md#high-accuracy-mode) currently enabled or not. This sensor will update as soon as the state of high accuracy mode changes, the sensor will not appear until high accuracy mode is enabled for the first time.

--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -544,6 +544,7 @@ These sensors will reflect health and fitness data stored by other apps on your 
 | `health_connect_nutrition_carbohydrates` | grams | <span class="beta">BETA</span> Total carbohydrates eaten since midnight. |
 | `health_connect_nutrition_fat` | grams | <span class="beta">BETA</span> Total fat eaten since midnight. |
 | `health_connect_nutrition_protein` | grams | <span class="beta">BETA</span> Total protein eaten since midnight. |
+| `health_connect_nutrition_sugar` | grams | <span class="beta">BETA</span> Total sugar eaten since midnight. |
 | `health_connect_oxygen_saturation` | percent | The last recorded oxygen saturation percentage. |
 | `health_connect_respiratory_rate` | breaths per minute | The last recorded respiratory rate. |
 | `health_connect_resting_heart_rate` | beats per minute | The last recorded resting heart rate. |

--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -540,6 +540,10 @@ These sensors will reflect health and fitness data stored by other apps on your 
 | `health_connect_heart_rate_variability` | milliseconds | The last recorded heart rate variability. |
 | `health_connect_height` | meters | The last recorded height. |
 | `health_connect_lean_body_mass` | grams | The last recorded lean body mass. |
+| `health_connect_nutrition_calories` | kilocalories | <span class="beta">BETA</span> Total calories eaten since midnight. |
+| `health_connect_nutrition_carbohydrates` | grams | <span class="beta">BETA</span> Total carbohydrates eaten since midnight. |
+| `health_connect_nutrition_fat` | grams | <span class="beta">BETA</span> Total fat eaten since midnight. |
+| `health_connect_nutrition_protein` | grams | <span class="beta">BETA</span> Total protein eaten since midnight. |
 | `health_connect_oxygen_saturation` | percent | The last recorded oxygen saturation percentage. |
 | `health_connect_respiratory_rate` | breaths per minute | The last recorded respiratory rate. |
 | `health_connect_resting_heart_rate` | beats per minute | The last recorded resting heart rate. |
@@ -548,17 +552,6 @@ These sensors will reflect health and fitness data stored by other apps on your 
 | `health_connect_total_calories_burned` | kilocalories | Total amount of calories burned since midnight, including active & basal energy burned (BMR). |
 | `health_connect_vo2_max` | milliliters per minute per kilogram | The last recorded VO2 max score. |
 | `health_connect_weight` | grams | The last recorded weight. |
-
-### <span class='beta'>BETA</span> Nutrition sensors
-
-These sensors provide daily nutrition totals from Nutrition records stored in Health Connect. They require the Android app's Nutrition support to be available.
-
-| Sensor | Unit | Description |
-| --------- | ---- | --------- |
-| `health_connect_nutrition_calories` | kilocalories | Total calories eaten since midnight. |
-| `health_connect_nutrition_carbohydrates` | grams | Total carbohydrates eaten since midnight. |
-| `health_connect_nutrition_fat` | grams | Total fat eaten since midnight. |
-| `health_connect_nutrition_protein` | grams | Total protein eaten since midnight. |
 
 ## High accuracy mode
 ![Android](/assets/android.svg) This sensors state will reflect if the device has [high accuracy mode](location.md#high-accuracy-mode) currently enabled or not. This sensor will update as soon as the state of high accuracy mode changes, the sensor will not appear until high accuracy mode is enabled for the first time.

--- a/docs/core/sensors.md
+++ b/docs/core/sensors.md
@@ -535,6 +535,10 @@ These sensors will reflect health and fitness data stored by other apps on your 
 | `health_connect_daily_floors` | floors | Total floors climbed since midnight. |
 | `health_connect_daily_hydration` | milliliters | Total hydration since midnight. |
 | `health_connect_daily_steps` | steps | Total steps taken since midnight. |
+| `health_connect_nutrition_calories` | kilocalories | Total calories eaten since midnight. |
+| `health_connect_nutrition_carbohydrates` | grams | Total carbohydrates eaten since midnight. |
+| `health_connect_nutrition_fat` | grams | Total fat eaten since midnight. |
+| `health_connect_nutrition_protein` | grams | Total protein eaten since midnight. |
 | `health_connect_diastolic_blood_pressure` | millimeters of Mercury | The last recorded diastolic blood pressure. |
 | `health_connect_heart_rate` | beats per minute | The last recorded heart rate. |
 | `health_connect_heart_rate_variability` | milliseconds | The last recorded heart rate variability. |


### PR DESCRIPTION
## Proposed change

Document the new Android Health Connect Nutrition sensors introduced in [Issue 7342](https://github.com/home-assistant/android/pull/7342), addressing the Nutrition item in [Issue #4804](https://github.com/home-assistant/android/issues/4804).

The documentation adds four sensors:

- Calories eaten
- Carbs eaten
- Fat eaten
- Protein eaten

Each sensor reports the total value recorded in Health Connect since midnight. The documentation-only section should be marked as `<span class='beta'>BETA</span>` until the Android pull request is merged and released.

## Type of change

- [ ] Document existing features within Home Assistant Companion App
- [x] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/general-style-guide).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information

- This PR fixes or closes issue: [#7342](https://github.com/home-assistant/android/pull/7342)
- Link to relevant existing code or pull request: [home-assistant/android#7342](https://github.com/home-assistant/android/pull/7342)
- Related feature request: [home-assistant/android#4804](https://github.com/home-assistant/android/issues/4804)
- Documentation file changed: `docs/core/sensors.md`