### PR TITLE
Rebuild CarPlay documentation

### DIFF
--- a/docs/carplay/assist.md
+++ b/docs/carplay/assist.md
@@ -5,63 +5,113 @@ id: "assist"
 
 ![iOS](/assets/iOS.svg)
 
-Assist is the voice assistant built into Home Assistant. It lets you control your smart home with natural language. When used with iOS CarPlay, Assist lets you start an Assist session, speak a request, and hear the response through your vehicle's audio system.
+Assist is the voice assistant built into Home Assistant. It lets you control your home by speaking normally, instead of finding the right button. In CarPlay, Assist records what you say, sends it to your Home Assistant server, and plays the answer through your vehicle's speakers.
 
-## Adding Assist to the Quick Access tab
+:::info
+Assist runs on your Home Assistant server, not in the app. Before you can use it in the car, you need an _Assist pipeline_ set up in Home Assistant. A pipeline is the combination of speech-to-text, a conversation agent, and text-to-speech that turns your voice into an action and the answer back into speech. See [Assist](https://www.home-assistant.io/voice_control/) in the Home Assistant documentation.
+:::
 
-### Prerequisites
+## Requirements
 
-- iOS 26.4 or later
-  - If your iPhone is running an older iOS version, Assist options may appear as **Assist (iOS 26.4+)** and cannot be added to CarPlay.
-- Have an [Assist pipeline configured in Home Assistant](https://www.home-assistant.io/voice_control/voice_remote_cloud_assistant/). 
-- If you want spoken responses in CarPlay, the selected pipeline must also have text-to-speech configured. 
+- iOS 26.4 or later.
 
-### To add Assist to CarPlay
+  If your iPhone runs an older version, the Assist options appear as **Assist (iOS 26.4+)** and **Assist prompt (iOS 26.4+)** and cannot be added.
 
-1. On your iPhone, open **Companion App Settings** > **CarPlay**.
-2. Open your **Quick Access** configuration.
-3. Add a new item and select **Assist**.
-4. Select the Assist pipeline you want to use.
-5. Save the item.
-    Result: The Assist item will appear in the **Quick Access** tab in CarPlay. 
+- An Assist pipeline in Home Assistant that has both speech-to-text and text-to-speech configured.
 
-## Using Assist from Quick Access
+  Pipelines missing either one are not offered. If you have none, the car shows **No Assist pipelines with both speech-to-text and text-to-speech available**.
 
-1. Open Quick Access.
-2. Tap Assist to start listening, then finish recording when you are done speaking. 
-3. The response will be processed and played as audio.
+## Adding Assist to Quick access
 
-## Adding Assist prompts
+Assist appears in CarPlay as an item in the **Quick access** tab, so you can add it once and use it on every drive.
 
-Assist prompts are predefined Assist requests that you can add as buttons in the **Quick Access** tab. Use them for requests you repeat often while driving, such as checking whether a door is open or announcing that you are arriving home soon.
+### From the car display
 
-### Prerequisites
+1. On the car display, open the **Quick access** tab.
+2. Select **Add item**.
+3. If you have more than one server, select your server.
+4. Select **Assist**.
+5. Select the pipeline you want to use, or select **Preferred** to always follow whichever pipeline is set as preferred in Home Assistant.
 
-- iOS 26.4 or later
-- Have Assist added to CarPlay
-- Make sure the selected pipeline has text-to-speech configured.
+### From your iPhone
 
-### To add an Assist prompt to CarPlay
+1. On your iPhone, go to **Settings** > **Apple Watch & CarPlay** > **CarPlay**.
+2. Select **Add item** > **Assist**.
+3. Select the pipeline you want to use.
+4. Select **Add**.
 
-1. On your iPhone, open **Companion App Settings** > **CarPlay**.
-2. Open your **Quick Access** configuration.
-3. Add a new item and select **Assist prompt**.
-4. Enter the **Title** that should appear in CarPlay.
-5. Enter the **Prompt** that should be sent to Assist.
-6. Select the Assist pipeline that should handle the prompt.
-7. Save the item.
+   Optionally, select the item afterwards to change its **Display text** or **Icon color**. The microphone icon is fixed and cannot be changed.
 
-## Using an Assist prompt in CarPlay
+:::note
+The **Start listening** switch on the item's screen applies to other places in the app. In CarPlay, Assist always starts listening as soon as you select it.
+:::
 
-1. Tap your prompt.
-    - When you tap an Assist prompt in CarPlay, the prompt is sent to the selected pipeline, and the response is played as audio.
-2. While an Assist prompt is open in CarPlay, you can replay the saved prompt or use the microphone button to start a new spoken Assist request.
+## Using Assist while driving
 
-## Troubleshooting the audio playback
+1. On the car display, open the **Quick access** tab and select your Assist item.
+2. Recording starts right away and the screen shows **Listening...**. Speak your request, such as "Turn off the kitchen lights".
+3. Select the microphone button when you are done speaking.
+4. The screen shows **Processing...** while your server works out what to do, then **Responding...** while the answer plays through your speakers.
 
-Some vehicles may not play spoken Assist responses when CarPlay is using the default streaming playback mode. If Assist works but you do not hear the response in your vehicle, change the TTS playback mode:
+The Assist screen has up to three buttons:
 
-1. On your iPhone, open **Companion App Settings** > **CarPlay**.
-2. Open **Troubleshooting** > **Assist**.
-3. Change **TTS Playback** from **Stream** to **Download and play**.
-    - Use **Download and play** only if **Stream** does not play audio reliably in your vehicle.
+- **Microphone**: start a new request.
+- **Replay**: send the saved prompt again. Only shown for Assist prompts.
+- **Question mark**: open **Audio Playback Help** if you cannot hear the response.
+
+If something goes wrong, the screen shows an error and you can select the microphone button to try again.
+
+## Assist prompts
+
+An Assist prompt is a request you write in advance and save as a button. Selecting it sends that exact request without you having to say anything, which is useful for things you ask often. For example:
+
+- `Is the garage door open?`
+- `Tell everyone I will be home in ten minutes.`
+- `Set the living room to movie mode.`
+
+### Adding an Assist prompt
+
+Assist prompts have to be typed, so they can only be created on your iPhone.
+
+1. On your iPhone, go to **Settings** > **Apple Watch & CarPlay** > **CarPlay**.
+2. Select **Add item** > **Assist prompt**.
+3. Enter the **Title** that should appear in the car, such as `Garage check`.
+4. Enter the **Prompt** that should be sent to Assist, such as `Is the garage door open?`.
+5. Select the pipeline that should handle it.
+6. Select **Add**.
+
+### Using an Assist prompt
+
+Select the prompt in the **Quick access** tab. The saved text is sent to Assist and the answer plays through your speakers. From that screen you can select the replay button to send the same prompt again, or the microphone button to ask something new.
+
+## Assist settings <span class="beta">BETA</span>
+
+Assist can use Apple's own speech recognition and speech synthesis on your iPhone instead of relying on your server for them. The two settings are independent, and they do different things:
+
+- **On-device STT** changes where your speech is recognized. Your voice is transcribed on your iPhone, and only the resulting text is sent to your server. Not all languages are supported.
+- **On-device TTS** changes where the response is spoken. The text your server returns is turned into speech on your iPhone, so no audio is downloaded from your server. Your voice is still sent to your server for recognition unless **On-device STT** is also turned on.
+
+These settings are shared between the app and CarPlay, so changing one changes both.
+
+### Changing them from the car
+
+1. On the car display, select **Settings** > **Assist Settings**.
+2. Select an option to turn it on. A check mark means it is on.
+   - **On-device STT**: transcribe your speech on your iPhone. When it is on, a **Language** row appears so you can pick the language.
+   - **On-device TTS**: speak the response using an Apple voice on your iPhone. When it is on, a **Voice** row appears so you can pick the voice.
+
+:::note
+The car offers the voices that match your iPhone's language, to keep the list short and safe to browse while driving. The full list of voices is available on your iPhone.
+:::
+
+### Changing them on your iPhone
+
+Go to **Settings** > **Apple Watch & CarPlay** > **CarPlay** > **Assist Settings**.
+
+:::info
+The **Mute voice responses** setting does not apply to CarPlay. Because the car is a voice-first interface, Assist responses always play out loud there.
+:::
+
+## If you cannot hear the response
+
+Some vehicles do not play spoken Assist responses when CarPlay streams the audio. If Assist clearly works but you hear nothing, change how the audio is played. See [Assist responses are not audible](troubleshooting.md#assist-responses-are-not-audible).

--- a/docs/carplay/carplay.md
+++ b/docs/carplay/carplay.md
@@ -5,32 +5,76 @@ id: "carplay"
 
 ![iOS](/assets/iOS.svg)
 
-Home Assistant offers a CarPlay experience. This will allow you to interact with various entities safely while driving your vehicle.
+Apple CarPlay shows apps from your iPhone on your vehicle's built-in display. The Home Assistant app supports CarPlay, so you can check and control your home from the car screen without picking up your phone.
 
-### Setup
+With Home Assistant in CarPlay you can:
 
-In order to use this integration you will need an iPhone as well as a vehicle with a head unit that supports CarPlay. Once you are signed in with your iPhone, you should be all set to use the Home Assistant icon on the CarPlay home screen.
-
-By default you won't see any relevant information in CarPlay, you need to open ***Companion App Settings → CarPlay***, and create your configuration. You can choose what tabs to display.
-
-### Tabs
-
-CarPlay has 4 tabs:
-
-- **Quick Access:** In your CarPlay configuration, you can decide what entities, Assist pipelines, and Assist prompts to display on the **Quick access** tab.
-
-- **Areas:** Brings easy access to your entities from the area in your home.
-- **Control:** Lets you access entities grouped by their domain.
-- **Servers:** Allows you to switch between servers.
+- Open the doors, turn on the lights, run a scene, or lock up from a shortcut list you build yourself.
+- Browse your home by area, or by the type of device you want to control.
+- Talk to [Assist](assist.md), the Home Assistant voice assistant, and hear the answer through your car speakers.
+- Change what the CarPlay screens show, directly from the car display.
 
 ![CarPlay](/assets/ios/CarPlay.png)
 
-See [Assist](assist.md) to configure Assist and Assist prompts in CarPlay.
+## Requirements
 
-### Supported Actionable Domains
+- An iPhone running iOS 16.4 or later, with the Home Assistant app installed and connected to at least one Home Assistant server.
+- A vehicle or aftermarket head unit that supports CarPlay.
 
+Some features need a newer version of iOS. Those requirements are listed where the feature is described.
+
+:::info
+CarPlay does not have its own connection to Home Assistant. Your iPhone does the work and sends the screens to the car, so your phone must be able to reach your server, either on your home network or from outside your home. If you cannot reach your home while away, see [networking](../troubleshooting/networking.md).
+:::
+
+## Setting up CarPlay for the first time
+
+1. Connect your iPhone to your vehicle, either with a cable or wirelessly, depending on what your vehicle supports.
+
+2. On the CarPlay home screen, select the **Home Assistant** icon.
+
+3. The first time you open it, the **Quick access** tab is empty, because you decide what goes there.
+
+   To fill it, either add items directly from the car display, or set it up on your iPhone. See [Configuration](configuration.md).
+
+:::note
+If the app cannot find a server, CarPlay shows an alert instead of your entities. Open the Home Assistant app on your iPhone, make sure you are signed in to a server, and try again. See [Troubleshooting](troubleshooting.md).
+:::
+
+## The CarPlay tabs
+
+CarPlay shows Home Assistant as a set of tabs along the top or side of the car display, depending on your vehicle. You choose which tabs appear and in which order.
+
+- **Quick access**: your own shortcut list. You decide which entities, [Assist](assist.md) pipelines, and Assist prompts appear here, so the things you use while driving are one tap away. This is the tab most people rely on.
+- **Areas**: your home grouped by area, such as **Garage** or **Kitchen**. Select an area to see the entities in it. Areas without any compatible entities are not shown.
+- **Control**: your home grouped by the type of device, such as **Cover**, **Light**, or **Lock**. Covers are listed first, so garage doors are quick to reach.
+- **Settings**: change your CarPlay setup from the car, pick which server to show, and open the troubleshooting options. See [Configuration](configuration.md).
+
+To begin with, **Quick access**, **Areas**, and **Settings** are shown. **Control** is available but turned off, so add it if you want it. See [Configuration](configuration.md).
+
+### Custom tabs <span class="beta">BETA</span>
+
+Besides the built-in tabs, you can create your own tabs and fill them with the entities you choose. A custom tab is useful when **Quick access** gets long. For example, you could have a **Garage** tab and a **Lights** tab. See [Folders and custom tabs](configuration.md#folders-and-custom-tabs).
+
+:::note
+CarPlay limits how many tabs a vehicle displays, and the limit depends on the vehicle. If you add more tabs than your vehicle can show, the extra tabs are not displayed.
+:::
+
+## What you can control
+
+Home Assistant only shows entities in CarPlay that make sense to use while driving. Entities marked as hidden in Home Assistant, and entities categorized as configuration or diagnostic, are never shown.
+
+:::info
+An _entity_ is a single thing Home Assistant knows about, such as one light, one lock, or one garage door. A _domain_ is the type of that thing, such as `light` or `lock`. To learn more, see [entities](https://www.home-assistant.io/docs/configuration/entities_domains/) in the Home Assistant documentation.
+:::
+
+These domains are available in CarPlay:
+
+- `automation`
 - `button`
 - `cover`
+- `fan`
+- `humidifier`
 - `input_boolean`
 - `input_button`
 - `light`
@@ -38,3 +82,18 @@ See [Assist](assist.md) to configure Assist and Assist prompts in CarPlay.
 - `scene`
 - `script`
 - `switch`
+- `valve`
+
+The following domains are also available, and open their own control screen instead of running an action when you select them:
+
+- `climate` <span class="beta">BETA</span>
+- `vacuum` <span class="beta">BETA</span>
+
+For what happens when you select an entity, and for the climate and vacuum control screens, see [Controlling your home](controls.md).
+
+## Next steps
+
+- [Configuration](configuration.md): choose your tabs, build your **Quick access** list, and change your setup from the car display.
+- [Controlling your home](controls.md): what happens when you select an entity, confirmations, and the climate and vacuum control screens.
+- [Assist](assist.md): use the Home Assistant voice assistant while driving.
+- [Troubleshooting](troubleshooting.md): fix missing entities, silent voice responses, and other problems.

--- a/docs/carplay/configuration.md
+++ b/docs/carplay/configuration.md
@@ -1,0 +1,176 @@
+---
+title: "Configuration"
+id: "configuration"
+---
+
+![iOS](/assets/iOS.svg)
+
+You decide what Home Assistant shows in CarPlay. There are two places to do it:
+
+- **In the car**: use the **Settings** tab on the car display. Most settings can be changed here, so you do not have to reach for your phone.
+- **On your iPhone**: open **Settings** > **Apple Watch & CarPlay** > **CarPlay** in the Home Assistant app. This is where the full set of options lives, including renaming items, choosing custom icons, and creating Assist prompts.
+
+Both places write to the same configuration, and changes are saved as you make them. If your phone is connected to the car while you change something on the phone, the car display updates right away.
+
+## Configuring from the car display
+
+Select the **Settings** tab on the car display.
+
+The **Settings** tab contains:
+
+- **Main server**: pick which Home Assistant server CarPlay shows. Only relevant if you have more than one server.
+- **Layout**: choose how the **Quick access** tab is drawn, either **List** or **Grid**. **Grid** requires iOS 26 or later.
+- **Tabs**: choose which tabs appear on the car display.
+- **Show Add and Edit buttons** <span class="beta">BETA</span>: show or hide the **Add item** and **Edit** rows in **Quick access**. Turn this off for a cleaner list once you are happy with your setup.
+- **Assist Settings**: on-device speech options for [Assist](assist.md).
+- **Troubleshooting**: options to try when something is not working. See [Troubleshooting](troubleshooting.md).
+
+### Choosing which tabs appear
+
+1. On the car display, select **Settings** > **Tabs**.
+2. Select a tab name to turn it on or off. A check mark means the tab is shown.
+
+:::note
+The **Settings** tab cannot be turned off from the car, so you never lose access to these options while driving. To remove it, use your iPhone.
+:::
+
+To change the order of the tabs, or to create a new tab, use your iPhone.
+
+### Adding an item to Quick access from the car
+
+1. On the car display, open the **Quick access** tab.
+2. Select **Add item**.
+3. If you have more than one server, select the server the entity belongs to.
+4. Choose what you want to add:
+   - **Areas**: browse your entities by room, such as **Garage**.
+   - **Control**: browse your entities by device type, such as **Cover** or **Light**.
+   - **Assist**: add an Assist pipeline so you can start a voice request from **Quick access**. See [Assist](assist.md).
+5. Select what you want to add:
+   - For **Areas** or **Control**, select the entity, then choose whether running it should ask first:
+     - **Require confirmation**: CarPlay asks you to confirm before it runs. A good choice for a garage door or a gate.
+     - **Add without confirmation**: one tap runs it.
+   - For **Assist**, select the pipeline. There is nothing to confirm, so the item is added straight away.
+
+The item appears in **Quick access** immediately.
+
+:::note
+You are not asked about confirmation for locks or for climate entities. Locks always confirm, and climate entities open a control screen rather than running an action. See [Controlling your home](controls.md).
+
+Some item types cannot be created from the car, because they need typing. If you select **Folder** or **Assist prompt**, CarPlay tells you to create it in the Home Assistant app on your iPhone instead.
+:::
+
+### Editing or removing an item from the car
+
+1. On the car display, open the **Quick access** tab.
+2. Select **Edit**.
+3. Select the item you want to change, then choose one of:
+   - **Delete**: remove the item from the list.
+   - **Require confirmation**: start asking for confirmation before running it.
+   - **Don't require confirmation**: stop asking for confirmation.
+
+For anything else, such as renaming an item or giving it a different icon, use your iPhone.
+
+:::info
+If you do not see the **Add item** and **Edit** rows, the **Show Add and Edit buttons** setting is turned off. Turn it back on under **Settings** on the car display, or on your iPhone.
+:::
+
+## Configuring from your iPhone
+
+1. On your iPhone, open the Home Assistant app.
+2. Go to **Settings** > **Apple Watch & CarPlay** > **CarPlay**.
+
+### Tabs
+
+Select **Tabs** to manage the car display's tabs.
+
+- **Active** lists the tabs that appear in the car, in the order they appear. Drag a tab by its handle to move it. Swipe a tab to the left to remove it.
+- **Inactive** lists tabs that are available but not shown. Select the plus button next to a tab to add it back.
+- Select **Add Tab** to create your own tab. See [Folders and custom tabs](#folders-and-custom-tabs).
+
+:::note
+CarPlay limits how many tabs are displayed in the car, and the limit depends on the vehicle. Extra tabs are not shown, so keep the ones you use most at the top of the **Active** list.
+:::
+
+### Quick access
+
+The **Quick access** section is where you build your shortcut list.
+
+- **Layout**: choose **List** or **Grid**. **Grid** fits more items on screen at once, and requires iOS 26 or later. On older versions the option is shown as unavailable.
+- Select **Add item** to add something to the list. You can add:
+  - **Entity**: a light, lock, cover, script, scene, or any other supported entity. See [What you can control](carplay.md#what-you-can-control).
+  - **Assist**: starts a voice request with a chosen Assist pipeline. Requires iOS 26.4 or later. See [Assist](assist.md).
+  - **Assist prompt**: sends a request you write in advance, such as `Is the garage door open?`. Requires iOS 26.4 or later. See [Assist](assist.md).
+  - **Add folder** <span class="beta">BETA</span>: groups items together. See [Folders and custom tabs](#folders-and-custom-tabs).
+- Drag an item by its handle to reorder it. Swipe left to delete it.
+- Select an item to customize it.
+
+#### Customizing an item
+
+Select an item in the **Quick access** list to change:
+
+- **Display text**: the name shown in the car. Leave it empty to use the name from Home Assistant.
+- **Icon**: pick a different icon.
+- **Icon color**: pick a color for the icon.
+- **Require confirmation**: ask before running the item.
+
+An Assist item adds a **Pipeline** setting, so you can change which pipeline it uses. It keeps **Display text** and **Icon color**, but its icon is always the microphone and cannot be changed, and it has no **Require confirmation** option because starting a voice request has nothing to confirm.
+
+:::note
+The **Start listening** switch on that screen does not apply to CarPlay, where Assist always starts listening as soon as you select it.
+:::
+
+### Show Add and Edit buttons <span class="beta">BETA</span>
+
+Turn this off to hide the **Add item** and **Edit** rows from the car display. The setting only changes what the car shows; you can still add and edit items on your iPhone.
+
+### Assist Settings
+
+Opens the Assist options shared by the app and the car, such as on-device speech recognition. See [Assist](assist.md).
+
+### Troubleshooting
+
+Opens the CarPlay troubleshooting options, including the audio playback setting for spoken Assist responses. See [Troubleshooting](troubleshooting.md).
+
+### Resetting your configuration
+
+Select **Reset configuration** to delete your CarPlay setup and start over. This cannot be undone, and you are asked to confirm first.
+
+## Folders and custom tabs <span class="beta">BETA</span> {#folders-and-custom-tabs}
+
+A folder is a group of items. Folders keep long lists manageable, and they are the building block for your own tabs.
+
+### Creating a folder
+
+1. On your iPhone, go to **Settings** > **Apple Watch & CarPlay** > **CarPlay**.
+2. Select **Add item** > **Add folder**.
+3. Enter a name, then select **Add folder**.
+4. Select the new folder to add items to it.
+
+In the car, a folder appears in **Quick access** with an arrow. Select it to see what is inside. You can also add items to a folder from the car, the same way you add them to **Quick access**.
+
+:::note
+Folders cannot contain other folders.
+:::
+
+### Creating your own tab
+
+1. On your iPhone, go to **Settings** > **Apple Watch & CarPlay** > **CarPlay** > **Tabs**.
+2. Select **Add Tab**.
+3. Enter a name, such as `Garage`, then select **Add Tab**.
+4. Select the new tab in the **Active** list to add items to it.
+
+A custom tab holds its own items, separate from **Quick access**. You can also turn an existing **Quick access** folder into a tab: it appears in the **Inactive** list under **Tabs**, ready to be added.
+
+:::warning
+Removing a custom tab you created under **Tabs** also deletes the items in it. A **Quick access** folder promoted to a tab is different: removing the tab only hides it, and the folder stays in **Quick access**.
+:::
+
+## Using more than one server
+
+If your iPhone is connected to several Home Assistant servers, CarPlay shows one server at a time. That server is your **Main server**.
+
+To switch servers from the car, select **Settings** > **Main server**, then select the server you want. A check mark shows the current one.
+
+:::info
+The **Quick access** tab is not limited to the main server. Each item remembers which server it belongs to, so a shortcut keeps working even when another server is selected as the main one.
+:::

--- a/docs/carplay/controls.md
+++ b/docs/carplay/controls.md
@@ -1,0 +1,89 @@
+---
+title: "Controlling your home"
+id: "controls"
+---
+
+![iOS](/assets/iOS.svg)
+
+This page explains what happens when you select something on the CarPlay screen.
+
+## Browsing your home
+
+Two tabs let you find any supported entity without setting anything up in advance:
+
+- **Areas**: select an area, such as **Garage**, then select an entity inside it. Areas with no compatible entities are not listed.
+- **Control**: select a device type, such as **Light**, then select an entity. Covers are listed first, so garage doors and gates are quick to reach.
+
+Every list shows the entity's current state under its name, such as **Open** or **Off**, and the icon changes with the state. Lists that do not fit on one screen have **Previous** and **Next** rows to page through them.
+
+## Selecting an entity
+
+What happens depends on the type of entity:
+
+- **Lights, switches, covers, fans, humidifiers, valves, and input booleans** are toggled. A light that is on turns off; a closed garage door opens.
+- **Scenes and scripts** are activated.
+- **Automations** are triggered.
+- **Buttons and input buttons** are pressed.
+- **Locks** are locked or unlocked, depending on their current state.
+- **Climate and vacuum entities** open their own control screen instead of running anything. See [Climate entities](#climate-entities-beta) and [Vacuum entities](#vacuum-entities-beta).
+
+While the request is being sent, the row shows **Executing...**, then goes back to showing the entity's state.
+
+## Confirmations
+
+Some things are worth double-checking before they run.
+
+- **Locks** always ask before locking or unlocking, and you cannot turn this off. This prevents an accidental tap from unlocking your front door.
+- **Everything else** asks only if you turned on **Require confirmation** for that item. You can set this when adding an item from the car, or at any time from your iPhone. See [Configuration](configuration.md).
+
+:::note
+Confirmation applies to items in **Quick access** and custom tabs. Selecting an entity from the **Areas** or **Control** tab runs it straight away, except for locks, which always confirm.
+:::
+
+## Climate entities <span class="beta">BETA</span>
+
+Selecting a climate entity, such as a thermostat or a heat pump, opens a control screen with the same options the Home Assistant dashboard offers. Only the options your device actually supports are shown.
+
+- **Temperature**: the target temperature, with **Increase** and **Decrease** controls. The current temperature is shown underneath.
+- **Heat to** and **Cool to**: for devices with a target range instead of a single temperature.
+- **Modes**: change the operating **Mode**, such as **Heat**, **Cool**, or **Off**. Depending on the device, you may also see **Fan mode**, **Swing mode**, **Horizontal swing**, and **Preset**.
+- **Humidity**: the target humidity, with **Increase** and **Decrease** controls.
+
+The screen updates as the device reports its new state, so you can see the change take effect.
+
+:::info
+On iOS 26 and later, the **Increase** and **Decrease** controls are drawn as large tiles that are easier to hit while driving. On earlier versions they appear as list rows.
+:::
+
+## Vacuum entities <span class="beta">BETA</span>
+
+Selecting a vacuum opens a control screen. As with climate entities, only the options your vacuum supports are shown.
+
+- **Start** or **Pause**: start cleaning, or pause a run in progress.
+- **Stop**: stop the current run.
+- **Return to dock**: send the vacuum back to its base.
+- **Locate**: make the vacuum play a sound so you can find it.
+- **Clean areas**: pick which areas to clean.
+- **Fan speed**: change the suction level.
+
+The battery level is shown at the top of the screen.
+
+### Cleaning specific areas
+
+1. On the vacuum's control screen, select **Clean areas**.
+2. Select each area you want cleaned. The order you select them in is the order they are cleaned, and each area shows its position in the queue.
+3. Select **Start cleaning** to send the job.
+
+:::note
+If you see **No areas mapped**, your vacuum's segments have not been matched to Home Assistant areas yet. This is set up in Home Assistant, not in the app.
+:::
+
+## When something does not appear
+
+Home Assistant deliberately hides some entities from CarPlay:
+
+- Entities marked as hidden in Home Assistant.
+- Entities categorized as configuration or diagnostic.
+- Entities whose domain is not supported. See [What you can control](carplay.md#what-you-can-control).
+
+If an entity you expect is missing for another reason, see [Troubleshooting](troubleshooting.md).

--- a/docs/carplay/troubleshooting.md
+++ b/docs/carplay/troubleshooting.md
@@ -1,0 +1,99 @@
+---
+title: "Troubleshooting"
+id: "troubleshooting"
+---
+
+![iOS](/assets/iOS.svg)
+
+This page covers the most common CarPlay problems and what to do about them.
+
+## Home Assistant does not appear in CarPlay
+
+- Make sure the Home Assistant app is installed on the iPhone you connect to the car.
+- Make sure your iPhone runs iOS 16.4 or later.
+- On some vehicles the CarPlay home screen has more than one page. Check the other pages.
+- If your vehicle lets you rearrange CarPlay icons, Home Assistant may have been hidden. On your iPhone, go to iOS **Settings** > **General** > **CarPlay**, select your vehicle, and check that Home Assistant is included.
+
+## The car says no servers are available
+
+CarPlay uses the servers your iPhone is signed in to. If the car shows **No servers available. Add a server in the app.**, open the Home Assistant app on your iPhone and sign in to your server, then try again.
+
+## Quick access is empty
+
+The **Quick access** tab starts out empty on purpose, because you choose what goes in it. Add items from the car display, or from your iPhone. See [Configuration](configuration.md).
+
+If you previously had items and they are gone, your iPhone may not have loaded its data. Force close the app and open it again. See [The lists are empty or out of date](#the-lists-are-empty-or-out-of-date).
+
+## An entity is missing
+
+Work through these in order:
+
+1. Check that the entity's type is supported. Home Assistant only offers some types in CarPlay. See [What you can control](carplay.md#what-you-can-control).
+2. In Home Assistant, check that the entity is not marked as hidden. Hidden entities are never shown in CarPlay.
+3. In Home Assistant, check that the entity's category is not set to configuration or diagnostic. Those are never shown either.
+4. Check that you are looking at the right server. The **Areas** and **Control** tabs only show the server selected under **Settings** > **Main server** in the car.
+5. If the lists look out of date, force close the app. See [The lists are empty or out of date](#the-lists-are-empty-or-out-of-date).
+
+## The lists are empty or out of date
+
+CarPlay uses data your iPhone has already downloaded from your server. If that data did not load properly, closing the app and letting it start again usually fixes it.
+
+1. On the car display, select **Settings** > **Troubleshooting**.
+2. Select **Force close app**.
+3. Open Home Assistant again from the CarPlay home screen.
+
+:::info
+**Force close app** closes the Home Assistant app right away so it starts fresh the next time you open it. Nothing is deleted, and your configuration is kept.
+:::
+
+## Assist responses are not audible
+
+Some vehicles do not play spoken Assist responses when CarPlay streams the audio. If [Assist](assist.md) clearly works, showing **Processing...** and **Responding...**, but you hear nothing, change how the audio is played.
+
+### From the car display
+
+1. On the car display, select **Settings** > **Troubleshooting** > **Assist audio**.
+2. Change **TTS Playback** from **Stream** to **Download and play**.
+
+### From your iPhone
+
+1. On your iPhone, go to **Settings** > **Apple Watch & CarPlay** > **CarPlay**.
+2. Select **Troubleshooting**.
+3. Change **TTS Playback** from **Stream** to **Download and play**.
+
+:::note
+Use **Download and play** only if **Stream** does not play audio reliably in your vehicle. **Stream** starts playing sooner, so it is the better choice when it works.
+:::
+
+You can also reach this advice from the car while an Assist session is open: select the question mark button to open **Audio Playback Help**.
+
+## Assist is not offered when adding an item
+
+- Assist and Assist prompts need iOS 26.4 or later. On older versions they are shown as **Assist (iOS 26.4+)** and **Assist prompt (iOS 26.4+)** and cannot be selected.
+- Your Assist pipeline needs both speech-to-text and text-to-speech configured. Pipelines missing either one are not listed.
+
+## Some tabs are missing from the car
+
+CarPlay limits how many tabs a vehicle displays, and the limit depends on the vehicle. Tabs beyond that limit are not shown.
+
+Reorder your tabs so the ones you use most come first: on your iPhone, go to **Settings** > **Apple Watch & CarPlay** > **CarPlay** > **Tabs**, then drag the tabs in the **Active** list.
+
+## The Add item and Edit rows are gone <span class="beta">BETA</span>
+
+The **Show Add and Edit buttons** setting is turned off. Turn it back on under **Settings** on the car display, or on your iPhone under **Settings** > **Apple Watch & CarPlay** > **CarPlay**.
+
+## Starting over
+
+If your setup is in a state you cannot untangle, you can delete it and build it again.
+
+1. On your iPhone, go to **Settings** > **Apple Watch & CarPlay** > **CarPlay**.
+2. Select **Reset configuration**.
+3. Confirm.
+
+:::warning
+This deletes your tabs, your **Quick access** items, and your folders. It cannot be undone.
+:::
+
+## Still stuck
+
+See [more help](../troubleshooting/more-help.md) for how to report a problem, or check the [iOS issue tracker](https://github.com/home-assistant/iOS/issues).

--- a/sidebars.js
+++ b/sidebars.js
@@ -70,7 +70,10 @@ module.exports = {
     ],
     'CarPlay': [
       'carplay/carplay',
-      'carplay/assist'
+      'carplay/configuration',
+      'carplay/controls',
+      'carplay/assist',
+      'carplay/troubleshooting'
     ],
     'macOS': [
       'macos/toolbar'


### PR DESCRIPTION
## Proposed change

Rebuilds the CarPlay documentation to match the current app. CarPlay can now be configured directly from the car display, so the docs are reorganized from two pages into five:

- **Overview**: requirements, first-time setup, the tabs, and the supported entity types.
- **Configuration**: setting up CarPlay from the car display and from the iPhone.
- **Controlling your home**: what happens when you select an entity, confirmations, and the climate and vacuum control screens.
- **Assist**: updated with the current pipeline requirements and the on-device speech settings.
- **Troubleshooting**: new page, including the audio playback setting that used to live on the Assist page.

Features not yet in a stable release are marked with the `<span class='beta'>BETA</span>` flag: folders and custom tabs, the add and edit buttons toggle, the climate and vacuum control screens, and the on-device Assist settings.

## Type of change

- [x] Document existing features within Home Assistant Companion App
- [ ] Document new or changing features for which there is an existing pull request elsewhere
- [ ] Spelling or grammatical corrections, or rewording for improved clarity
- [ ] Changes to the backend of this documentation
- [ ] Remove stale or deprecated documentation

## Checklist

- [x] I have read and followed the [documentation guidelines](https://developers.home-assistant.io/docs/documenting/general-style-guide).
- [x] I have verified that my changes render correctly in the documentation.

## Additional information

- This PR fixes or closes issue: Fixes #
- Link to relevant existing code or pull request: Screenshots for the new screens still need to be added in a follow-up.
